### PR TITLE
Fix: wrong link for tags

### DIFF
--- a/_includes/tags_list.html
+++ b/_includes/tags_list.html
@@ -6,7 +6,7 @@
         <div class="meta">Tags</div>
       {% endif %}
       {% for tag in page.tags %}
-        <a class="button" href="{{site.baseurl}}/pages/tags#{{tag}}">
+        <a class="button" href="{{site.baseurl}}/tags#{{tag}}">
           <i class="fa fa-tag fa-fw"></i> {{ tag }}
         </a>
       {% endfor %}


### PR DESCRIPTION
CF https://github.com/Sylhare/Type-on-Strap/issues/7#issuecomment-343613873

![kapture 2017-11-11 at 0 24 01](https://user-images.githubusercontent.com/13712263/32682747-0479290a-c677-11e7-834c-111efbb8d85a.gif)

Page link is like this : `http://127.0.0.1:4000/pages/tags/#micodeyt`, now `http://127.0.0.1:4000/tags/#micodeyt`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sylhare/type-on-strap/21)
<!-- Reviewable:end -->
