### PR TITLE
Change Keybase social link to HTTPS

### DIFF
--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -110,7 +110,7 @@
 
 {% if site.theme_settings.keybase %}
 <li>
-	<a href="http://keybase.io/{{ site.theme_settings.keybase }}" title="{{ site.theme_settings.str_follow_on }} Keybase">
+	<a href="https://keybase.io/{{ site.theme_settings.keybase }}" title="{{ site.theme_settings.str_follow_on }} Keybase">
 		<span class="fa-stack fa-lg">
             <i class="fa fa-circle fa-stack-2x"></i>
             <i class="fa fa-key fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
In #33 I made the Keybase link HTTP instead of HTTPS.

It should be HTTPS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sylhare/type-on-strap/35)
<!-- Reviewable:end -->
