### PR TITLE
#43 Fix: Parsing markdown into HTML

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/0.3.9/marked.js"></script>
 <div class="home">
   {% if site.theme_settings.header_text %}
   <div id="main" class="call-out"
@@ -30,7 +30,9 @@ layout: default
             </p>
           </header>
           <div class="excerpt">
-            {{ post.content | strip_html | truncate: "250" }}
+            <div id="post_content" class="excerpt">
+              {{ post.content | strip_html | truncate: "250" }}
+            </div>
             <!--<a class="button" href="{{ post.url | prepend: site.baseurl }}">
               {{ site.theme_settings.str_continue_reading }}
             </a>-->
@@ -57,3 +59,6 @@ layout: default
   </div>
   {% endif %}
 </div>
+<script>
+  document.getElementById('post_content').innerHTML = (marked(document.getElementById("results").innerHTML));
+</script>


### PR DESCRIPTION
This is a fix for #43.
It uses [marked.js](https://github.com/chjj/marked/blob/master/lib/marked.js) to parse the markdown content of the post to HTML
Kindly review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sylhare/type-on-strap/45)
<!-- Reviewable:end -->
