### PR TITLE
Added separator and empty footer to improvement UI

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -21,6 +21,9 @@
     <ul>
         {% for page in site.pages %}
         {% if page.title and page.hide != true %}
+        <li class="separator">
+            |
+        </li>
         <li>
             <a class="clear" href="{{ page.url | relative_url }}">
                 {{ page.title }}
@@ -29,6 +32,9 @@
         {% endif %}
         {% endfor %} 
         {% if site.theme_settings.portfolio %}
+        <li class="separator">
+            |
+        </li>
         <li>
             <a class="clear" href="{{ site.url }}{{ site.baseurl }}/portfolio">
                 Portfolio
@@ -36,6 +42,9 @@
         </li>
         {% endif %}
         {% if site.theme_settings.search %}
+        <li class="separator">
+            |
+        </li>
         <li>
             <a class="clear" href="{{ site.url }}{{ site.baseurl }}/search">
                 <i class="fa fa-search" aria-hidden="true"></i>
@@ -43,6 +52,9 @@
         </li>
         {% endif %}
         {% if site.theme_settings.tags %}
+        <li class="separator">
+            |
+        </li>
         <li>
             <a class="clear" href="{{ site.url }}{{ site.baseurl }}/tags">
                 <i class="fa fa-tags" aria-hidden="true"></i>

--- a/_includes/tags_list.html
+++ b/_includes/tags_list.html
@@ -1,19 +1,23 @@
 {% assign tags = include.tags | split:'|' | sort | uniq %}
 
 {% if include.tags.size > 0 %}
-    <footer>
-        <div class="tag-list">
-        {% if include.tags.size == 1 %}
-          <div class="meta">Tag</div>
-        {% elsif include.tags.size > 1 %}
-          <div class="meta">Tags</div>
-        {% endif %}
-            
-        {% for tag in tags %}
-          <a class="button" href="{{site.baseurl}}/tags#{{tag}}">
-            <p><i class="fa fa-tag fa-fw"></i> {{ tag }}</p>
-          </a>
-        {% endfor %}
-        </div>
-    </footer>
-  {% endif %}
+<footer>
+  <div class="tag-list">
+    {% if include.tags.size == 1 %}
+      <div class="meta">Tag</div>
+    {% elsif include.tags.size > 1 %}
+      <div class="meta">Tags</div>
+    {% endif %}
+
+    {% for tag in tags %}
+    <a class="button" href="{{site.baseurl}}/tags#{{tag}}">
+      <p><i class="fa fa-tag fa-fw"></i> {{ tag }}</p>
+    </a>
+    {% endfor %}
+  </div>
+</footer>
+{% else %}
+<footer>
+  <div class="tag-list"></div>
+</footer>
+{% endif %}

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -27,6 +27,7 @@ $search-color: #999;
 
 // Header colours
 $header-link-color: #383838;
+$navbar-separator-opacity: 0.3;
 
 // Feature image for articles
 $feature-image-text-color: #fff;

--- a/_sass/includes/_navbar.scss
+++ b/_sass/includes/_navbar.scss
@@ -5,6 +5,15 @@
     float: left;
     width: 100%;
 
+    .separator {
+        user-select: none;
+        opacity: $navbar-separator-opacity;
+
+        &:first-child {
+            display: none;
+        }
+    }
+
     a {
         color: $header-link-color;
     }
@@ -96,6 +105,10 @@
 
     nav {
         height: auto;
+
+        .separator {
+            display: none !important;
+        }
 
         ul {
             width: 100%;


### PR DESCRIPTION
This is a really great theme overall, and after using it I found several possible UI improvements. 

#### 1. Added separators between navbar items to provide better visual.

Before
![Before add separator](https://i.imgur.com/KH0QZTc.png) . 
After
![After add separator](https://i.imgur.com/uoLjoC2.png)
And this won't affect mobile experience as these separators are set to `display:none` on the small screen as shown here:
![shown here](https://imgur.com/Vv7ZKmQ.png).

#### 2. Added an empty footer for pages/posts without tags to avoid narrow bottom part.
    
As shown on the demo's search page:
 ![demo's tag page](https://imgur.com/TEqigIS.png)
The bottom border of the last result would be too close to the outer layer's bottom border, which is not perfect.

```
<footer>
  <div class="tag-list"></div>
</footer>
```

A simple fix is to add an empty footer element to each page/post, resulting in:
![this](https://imgur.com/dF2JlrE.png).

Also, without this change, posts with feature-image but without tags would have inconsistent looking.
Before:
![Imgur](https://i.imgur.com/nvGgN6E.png)
After:
![Imgur](https://i.imgur.com/ht2jeBj.png)