### PR TITLE
Fix _config.yml for customizable title, description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,15 +1,15 @@
 # SITE CONFIGURATION
 baseurl: "/Type-on-Strap"
 url: "https://sylhare.github.io"
-
+title: Type on Strap # site's title
+description: "A website with blog posts and pages" # used by search engines
 # THEME-SPECIFIC CONFIGURATION
 theme_settings:
   # Meta
-  title: Type on Strap
+  title: Type on Strap # blog's title
   avatar: assets/img/triangle.svg
   favicon: assets/favicon.ico
   gravatar: # Email MD5 hash
-  description: "A website with blog posts and pages" # used by search engines
 
   # Header and footer text
   header_text: > #two or three lines to describe your site


### PR DESCRIPTION
On #17, @frigaut asked about how to change the site's title, since it always shows a same description `"Simplistic, responsive jekyll based open source theme"`, and you said it's not yet customizable.

I fixed `_config.yml` so that jekyll-seo-tag can automatically generates site's custom title and description properly.

---

In [_includes/head.html](https://github.com/Sylhare/Type-on-Strap/blob/master/_includes/head.html), actually there is  a code that generates site's custom title and description from `_config.yml`'s `theme_settings:title`, `theme_settings:title` but it's manually disabled by commenting out 4 months ago.

```
    <!-- Manual seo tags -->
    <!--
    <title>{% if page.title %}{{ page.title }} |{% endif %} {{ site.theme_settings.title }}</title>
    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.theme_settings.description }}{% endif %}">
    -->
```

I'm not sure you intended that for later implementation, if you did, please ignore this PR.