### PR TITLE
Added configurable social media share buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,19 @@ theme_settings:
   vimeo:
   wordpress:
   youtube:
+  
+  # Sharing options
+  share_buttons:
+    facebook: true
+    twitter: true
+    google_plus: true
+    tumblr:
+    pinterest:
+    pocket:
+    reddit: true
+    linkedin:
+    wordpress:
+    email: true
 
   # Scripts / Features 
   google_analytics: # Tracking ID, e.g. "UA-000000-01"
@@ -61,7 +74,11 @@ theme_settings:
   # Localization strings
   str_follow_on: "Follow on"
   str_rss_follow: "Follow RSS feed"
+  str_share_on: "Share on"
+  str_add_to: "Add to"
   str_email: "Email"
+  str_tweet: "Tweet"
+  str_pin_it: "Pin it"
   str_next_post: "Next post"
   str_previous_post: "Previous post"
   str_next_page: "Next"

--- a/_includes/share_buttons.html
+++ b/_includes/share_buttons.html
@@ -1,0 +1,95 @@
+<footer>
+<div class="share-buttons">
+<ul class="share-buttons">
+	{% if site.theme_settings.share_buttons.facebook %}
+	<li>
+		<a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | prepend: site.baseurl | prepend: site.url }}&quote={{ page.title }}%20%7C%20{{ site.title }}" target="_blank" title="{{ site.theme_settings.str_share_on }} Facebook">
+			<i class="fa fa-facebook-square fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_share_on }} Facebook</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.twitter %}
+	<li>
+		<a href="https://twitter.com/intent/tweet?source={{ page.url | prepend: site.baseurl | prepend: site.url }}&text={{ page.title }}%20%7C%20{{ site.title }}:%20{{ page.url | prepend: site.baseurl | prepend: site.url }}" target="_blank" title="{{ site.theme_settings.str_tweet }}">
+			<i class="fa fa-twitter-square fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_tweet }}</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.google_plus %}
+	<li>
+		<a href="https://plus.google.com/share?url={{ page.url | prepend: site.baseurl | prepend: site.url }}" target="_blank" title="{{ site.theme_settings.str_share_on }} Google+">
+			<i class="fa fa-google-plus-square fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_share_on }} Google+</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.tumblr %}
+	<li>
+		<a href="http://www.tumblr.com/share?v=3&u={{ page.url | prepend: site.baseurl | prepend: site.url }}&quote={{ page.title }}%20%7C%20{{ site.title }}&s=" target="_blank" title="{{ site.theme_settings.str_share_on }} Tumblr">
+			<i class="fa fa-tumblr-square fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_share_on }} Tumblr</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.pinterest %}
+	<li>
+		<a href="http://pinterest.com/pin/create/button/?url={{ page.url | prepend: site.baseurl | prepend: site.url }}&description=" target="_blank" title="{{ site.theme_settings.str_pin_it }}">
+			<i class="fa fa-pinterest-square fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_pin_it }}</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.pocket %}
+	<li>
+		<a href="https://getpocket.com/save?url={{ page.url | prepend: site.baseurl | prepend: site.url }}&title={{ page.title }}%20%7C%20{{ site.title }}" target="_blank" title="{{ site.theme_settings.str_add_to }} Pocket">
+			<i class="fa fa fa-get-pocket fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_add_to }} Pocket</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.reddit %}
+	<li>
+		<a href="http://www.reddit.com/submit?url={{ page.url | prepend: site.baseurl | prepend: site.url }}&title={{ page.title }}%20%7C%20{{ site.title }}" target="_blank" title="{{ site.theme_settings.str_share_on }} Reddit">
+			<i class="fa fa-reddit-square fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_share_on }} Reddit</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.linkedin %}
+	<li>
+		<a href="http://www.linkedin.com/shareArticle?mini=true&url={{ page.url | prepend: site.baseurl | prepend: site.url }}&title={{ page.title }}%20%7C%20{{ site.title }}&summary=&source={{ page.url | prepend: site.baseurl | prepend: site.url }}" target="_blank" title="{{ site.theme_settings.str_share_on }} LinkedIn">
+			<i class="fa fa-linkedin fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_share_on }} LinkedIn</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.wordpress %}
+	<li>
+		<a href="http://wordpress.com/press-this.php?u={{ page.url | prepend: site.baseurl | prepend: site.url }}&quote={{ page.title }}%20%7C%20{{ site.title }}&s=" target="_blank" title="{{ site.theme_settings.str_share_on }} WordPress">
+			<i class="fa fa-wordpress fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_share_on }} WordPress</span>
+		</a>
+	</li>
+	{% endif %}
+
+	{% if site.theme_settings.share_buttons.email %}
+	<li>
+		<a href="mailto:?subject={{ page.title }}%20%7C%20{{ site.title }}&body=:%20{{ page.url | prepend: site.baseurl | prepend: site.url }}" target="_blank" title="{{ site.theme_settings.str_email }}">
+			<i class="fa fa-envelope-square fa-2x" aria-hidden="true"></i>
+			<span class="sr-only">{{ site.theme_settings.str_email }}</span>
+		</a>
+	</li>
+	{% endif %}
+</ul>
+</div>
+</footer>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,6 +10,9 @@ layout: default
     </p>
   </header>
   <section class="post-content">{{ content }}</section>
+  
+  <!-- Social media shares -->
+  {% include share_buttons.html %}
    
    <!-- Tag list -->
   {% capture tag_list %}{{ page.tags | join: "|"}}{% endcapture %}

--- a/_sass/includes/_share_buttons.scss
+++ b/_sass/includes/_share_buttons.scss
@@ -1,0 +1,20 @@
+ul.share-buttons{
+  list-style: none;
+  padding: 0;
+  text-align: left;
+}
+
+ul.share-buttons li{
+  display: inline;
+}
+
+ul.share-buttons .sr-only{
+  position: absolute;
+  clip: rect(1px 1px 1px 1px);
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+}

--- a/_sass/type-on-strap.scss
+++ b/_sass/type-on-strap.scss
@@ -22,3 +22,4 @@
 @import 'includes/navbar';
 @import 'includes/portfolio';
 @import 'includes/grid';
+@import 'includes/share_buttons';


### PR DESCRIPTION
This pull request adds social media share buttons below posts, as suggested by #77.

Buttons have been generated from this website:
https://simplesharingbuttons.com/#networks

Following changes have been performed to make buttons integrate with the theme as seamlessly as possible:
- Migrated back to Font Awesome 4 (generated code uses FA5 tags).
- Removed any traces of JavaScript from generated links, now generating content purely via Jekyll tags.
- Made fully configurable via the config file.
- Exposed translateable strings to the config file.

As for CSS, the only change was made to buttons' alignment, they are now aligned to the left. This is a matter of personal preference, so should you prefer them centered, feel free to revert this.

Default configuration enables only some of the buttons as a proof of concept - again, I enabled some basing purely on personal preference.