### PR TITLE
Fix bugs related to tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,7 +65,7 @@ theme_settings:
   
   special_page:
     search: 
-      icon: "search" # Assuming page link and icon are the same
+      icon: "search"
       enabled: true
     tags:
       icon: "tags"

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -42,7 +42,7 @@
           {% if item[1].enabled %}
             <li class="separator"> | </li>
             <li>
-                <a class="clear" href="{{ site.url }}{{ site.baseurl }}/{{ item[1].icon }}">
+                <a class="clear" href="{{ site.url }}{{ site.baseurl }}/{{ item[0] }}">
                     <i class="fa fa-{{ item[1].icon }}" aria-hidden="true"></i>
                 </a>
             </li>

--- a/_includes/tags_list.html
+++ b/_includes/tags_list.html
@@ -1,11 +1,11 @@
 {% assign tags = include.tags | split:'|' | sort | uniq %}
 
-{% if include.tags.size > 0 %}
+{% if tags.size > 0 %}
 <footer>
   <div class="tag-list">
-    {% if include.tags.size == 1 %}
+    {% if tags.size == 1 %}
       <div class="meta">Tag</div>
-    {% elsif include.tags.size > 1 %}
+    {% else %}
       <div class="meta">Tags</div>
     {% endif %}
 

--- a/_layouts/tags.html
+++ b/_layouts/tags.html
@@ -7,8 +7,10 @@ layout: page
 <!-- cycles through posts to get tags -->
 {% assign rawtags = "" %}
 {% for post in site.posts %}
+{% if post.tags.size > 0 %}
 {% assign post_tags = post.tags | join:'|' | append:'|' %}
 {% assign rawtags = rawtags | append:post_tags %}
+{% endif %}
 {% endfor %}
 
 <!-- cycles through portfolio collection to get tags -->
@@ -20,7 +22,7 @@ layout: page
 
 <!-- cycles through pages to get tags -->
 {% for page in site.pages %}
-{% if page.tags %}
+{% if page.tags.size > 0 %}
 {% assign page_tags = page.tags | join:'|' | append:'|' %}
 {% assign rawtags = rawtags | append:page_tags %}
 {% endif %}


### PR DESCRIPTION
1)When bringing back tags to my blog, I noticed the code determining whether to display Tag or Tags is wrong. It was not using a tokenized array, therefore `.size` checked a length of the entire string of tags, not the amount of tags!

Now it functions as expected, so if only one tag is present then Tag will be displayed - else, Tags is selected.

2) Removed a "navbar icon must equal page URL" assumption - it broke for me when I renamed Tags to Categories! Now it works as expected.

3) #98 somewhat fixed an issue where pages with no tags would generate an empty, broken tag on a tags list. However, nothing like this was present for posts so the issue would still persist for them! Moreover, I noticed existing condition did not filter out empty lists properly - fixed that too. Current implementation has been tested and confirmed to work properly.