### PR TITLE
Makes portfolio captions configurable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,7 +92,11 @@ theme_settings:
 
   # Post navigation
   post_navigation: true
-  
+
+  # Controls whether in the portfolio, the item titles are shown
+  # when hovering over the images or as captions under the images
+  show_caption: false
+  hover_caption: true
   
 # PAGINATION
 paginate: 5

--- a/_includes/portfolio.html
+++ b/_includes/portfolio.html
@@ -4,12 +4,17 @@
     {% for item in site.portfolio %}
     <div class="portfolio-cell">
         <a href="{{ site.baseurl }}{{ item.url }}" class="portfolio-link" data-keyboard="true">
+	    {% unless site.theme_settings.hover_caption == false %}
             <div class="caption" title="{{ item.title }}">
                 <div class="caption-content">
                     <i class="fa fa-search-plus fa-3x"></i>
                 </div>
             </div>
-            <img src="{{ site.baseurl }}/{{ item.img }}" class="" alt="">
+	    {% endunless %}
+            <img src="{{ site.baseurl }}/{{ item.img }}" class="" alt="{{ page.title }}">
+	    {% if site.theme_settings.show_caption %}
+	    <div class="caption-content"><center> {{ item.title }} </center></div>
+	    {% endif %}
         </a>
     </div>
     {% endfor %}


### PR DESCRIPTION
Adds a portfolio configuration option that controls whether
the item titles are shown when hovering over the images or as
captions under the images.

Also uses item titles for the alt field in the img tag,
improving accessibilty.