### PR TITLE
Wrote a git pre-commit hook for gulp (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Use it in any markdown file. There are two fields in the include you need to loo
 
 #### Code highlight
 
-Like all CSS variables in the theme, you can edit the color of the code highlight in _sass > base > _variables.scss.
+Like all CSS variables in the theme, you can edit the color of the code highlight in `_sass > base > _variables.scss`.
 The code highlighting works with [base16](https://github.com/chriskempson/base16-html-previews/tree/master/css) you can find existing example 
 of your favourite highlight color scheme on this format.
 
@@ -536,6 +536,15 @@ gulp post -n 'title of the post'
 
 A file will be create following the format `yyyy-mm-dd-title-of-the-post.md` with default post attributes inside.
 Nothing will happen if the file exists already.
+
+### Git hooks
+Git hooks are provided in `hooks/`. The pre-commit hook, when enabled, will check for Gulp and gulpfile.js and auto-optimize assets every time you commit.
+
+To install the hook:
+
+`ln lib/hooks/pre-commit .git/hooks/pre-commit`
+
+*Note: It's still a work in progress.*
 
 ### Use as Ruby Gem 💎
 

--- a/lib/hooks/pre-commit
+++ b/lib/hooks/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Called by "git commit" with no arguments.
+# The hook should run gulp to optimize assets.
+# Will exit with non-zero status if it wants to stop the commit.
+
+# Detect if it's on the right dir and try to fix. Abort commit otherwise.
+if [ ${PWD##*/} != "lib" ] ; then
+    cd lib || exit 1
+fi 
+
+# Detect if gulp is intalled and gulpfile.js is present. Abort commit otherwise.
+if ! [ -f "gulpfile.js" ] || ! command -v gulp; then  
+    printf "gulpfile.js not found or gulp-cli not installed!\n"
+    exit 1
+fi
+
+# Detect if there are assets to optimize and, then, run gulp default task.
+if git status --porcelain | grep assets/_ >/dev/null; then
+    gulp 
+    # Asks if user wants to abort the commit. 
+    # FIXME: Git overrides STDIN, this is fundamentally flawed.
+    # TODO: Husky may be an alternative, https://github.com/typicode/husky 
+    printf "Do you want to abort the commit and stage more files? (Y/n) "
+    read -r answer
+    case ${answer:0:1} in
+        y|Y) exit 1;;
+        *) exit 0;;
+    esac
+fi
+
+# Proceed with the commit.
+exit 0
+


### PR DESCRIPTION
It is not working as intended because Git overrides STDIN and thus is impossible to read user input and make the choice to abort or continue. Although it's safe to merge because the hook will only be active after copying it to `.git/hooks/`.