### PR TITLE
Create a squared share icon for Pocket

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -33,7 +33,7 @@ share:
   twitter: true
   tumblr:
   pinterest:
-  pocket:
+  pocket: true
   reddit: true
   linkedin:
   wordpress:

--- a/_includes/share_buttons.html
+++ b/_includes/share_buttons.html
@@ -42,7 +42,10 @@
         {% endif %} {% if site.data.social.share.pocket or site.theme_settings.pocket %}
         <li>
             <a href="https://getpocket.com/save?url={{ page.url | absolute_url }}&title={{ page.title | url_encode }}%20%7C%20{{ site.title | url_encode }}" target="_blank" title="{{ site.data.social.language.str_add_to }} Pocket">
-			<i class="fab fa fa-get-pocket fa-2x" aria-hidden="true"></i>
+            <span class="fa-stack fa-1x" style="vertical-align: top">
+              <i class="fas fa-square fa-stack-2x" aria-hidden="true"></i>
+              <i class="fab fa-get-pocket fa-stack-1x fa-inverse" aria-hidden="true"></i>
+            </span>
 			<span class="sr-only">{{ site.data.social.language.str_add_to | default: "Add to" }} Pocket</span>
 		</a>
         </li>

--- a/_sass/includes/_share_buttons.scss
+++ b/_sass/includes/_share_buttons.scss
@@ -7,6 +7,7 @@ ul.share-buttons {
   div.meta {
     display: inline;
     margin-right: 0.5em;
+    vertical-align: super;
   }
 
   li {
@@ -26,5 +27,14 @@ ul.share-buttons {
     height: 1px;
     width: 1px;
     overflow: hidden;
+  }
+
+  .fa-stack {
+    vertical-align: top;
+    width: 1.75em;
+
+    .fab {
+      font-size: 30px;
+    }
   }
 }


### PR DESCRIPTION
## Problem
FontAwesome don't have an squared icon for Pocket and the standard icon does not fit with the other squared icons

## Changes
- Create squared Pocket icon using FA stacked icons. 
- Adjust CSS to fit and align the new icon with the others.
- Fix meta text alignment.
- Enable Pocket share icon in template.

**Before**
![Screenshot from 2021-03-23 20-02-01](https://user-images.githubusercontent.com/13279154/112232122-cbb8ff00-8c16-11eb-8d1a-86f49e6c66c4.png)

**After**
![Screenshot from 2021-03-23 20-32-09](https://user-images.githubusercontent.com/13279154/112232169-dc697500-8c16-11eb-83a5-7fcd32c44cbe.png)



