### PR TITLE
Dark Mode

### DIFF
--- a/_sass/base/_highlight.scss
+++ b/_sass/base/_highlight.scss
@@ -88,6 +88,10 @@ table.rouge-table {
 
 .highlight pre {
   width: 100%
+
+  ::selection {
+    background-color: $base02
+  }
 }
 
 .highlight .hll {

--- a/_sass/base/_highlight.scss
+++ b/_sass/base/_highlight.scss
@@ -102,15 +102,15 @@ table.rouge-table {
   .bp{ /* Name.Builtin.Pseudo */
     color: $base0c  }
   .c { /* Comment */
-    color: $base04 }
+    color: $base03 }
   .cm{ /* Comment.Multiline */
-    color: $base04  }
+    color: $base03  }
   .cp{ /* Comment.Preproc */
-    color: $base04  }
+    color: $base03  }
   .c1{ /* Comment.Single */
-    color: $base04  }
+    color: $base03  }
   .cs{ /* Comment.Special */
-    color: $base04  }
+    color: $base03  }
   .dl{ /* String.Quotes 8 */
     color: $base0a  }
   .err { /* Error */

--- a/_sass/base/_highlight.scss
+++ b/_sass/base/_highlight.scss
@@ -48,10 +48,11 @@ figure.highlight {
 code.highlighter-rouge {
   padding: 0.2em 0.4em;
   font-size: $font-size-code;
-  background-color: transparentize($base00, 0.85);
-  color: rgb(36, 41, 46);
+  background-color: transparentize($blockquote-color, 0.85);
+  color: $background-color;
   border-radius: 2px;
   font-family: $monospace;
+  filter: invert(100%) contrast(200%);
 }
 
 table.rouge-table {

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -59,6 +59,7 @@ $font-size-code: 0.85em !default;
 $font-height-code: 1.3em !default;
 $border-radius: 4px !default;
 
+/*
 // base16 Material Theme
 $base00: #302f2d !default; // Default Background
 $base01: #2E3C43 !default; // Lighter Background (Used for status bars) - NOT USED
@@ -76,22 +77,43 @@ $base0c: #89DDFF !default; // Support, Regular Expressions, Escape Characters, M
 $base0d: #82AAFF !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
 $base0e: #C792EA !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
 $base0f: #FF5370 !default; // Deprecated, Opening/Closing Embedded Language Tags e.g.
+*/
 
+/*
 // base16 Monokai
-//$base00: #272822 !default; // Default Background
-//$base01: #383830 !default; // Lighter Background (Used for status bars)
-//$base02: #49483e !default; // Selection Background
-//$base03: #75715e !default; // Dark Foreground (Used for status bars)
-//$base04: #a59f85 !default; // Comments, Invisible, Line Highlighting
-//$base05: #f8f8f2 !default; // Light Foreground (Not often used)
-//$base06: #f5f4f1 !default; // Light Background (Not often used)
-//$base07: #f9f8f5 !default; // Default text color
-//$base08: #f92672 !default; // Parenthesis, Caret, Delimiters, Operators
-//$base09: #fd971f !default; // Classes, Markup Bold, Search Text Background
-//$base0a: #e6db74 !default; // Strings, Inherited Class, Markup Code, Diff Inserted
-//$base0b: #a6e22e !default; // Functions, Methods, Attribute IDs, Headings
-//$base0c: #a1efe4 !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
-//$base0d: #66d9ef !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
-//$base0e: #ae81ff !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
-//$base0f: #cc6633 !default; // Deprecated, Opening/Closing Embedded Language Tags e.g.
+$base00: #272822 !default; // Default Background
+$base01: #383830 !default; // Lighter Background (Used for status bars)
+$base02: #49483e !default; // Selection Background
+$base03: #75715e !default; // Dark Foreground (Used for status bars)
+$base04: #a59f85 !default; // Comments, Invisible, Line Highlighting
+$base05: #f8f8f2 !default; // Light Foreground (Not often used)
+$base06: #f5f4f1 !default; // Light Background (Not often used)
+$base07: #f9f8f5 !default; // Default text color
+$base08: #f92672 !default; // Parenthesis, Caret, Delimiters, Operators
+$base09: #fd971f !default; // Classes, Markup Bold, Search Text Background
+$base0a: #e6db74 !default; // Strings, Inherited Class, Markup Code, Diff Inserted
+$base0b: #a6e22e !default; // Functions, Methods, Attribute IDs, Headings
+$base0c: #a1efe4 !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
+$base0d: #66d9ef !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
+$base0e: #ae81ff !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
+$base0f: #cc6633 !default; // Deprecated, Opening/Closing Embedded Language Tags e.g.
+*/
+
+// base16 Nebula
+$base00: #2a373d !default; // Default Background
+$base01: #334046 !default; // Lighter Background (Used for status bars, line number and folding marks)
+$base02: #1b252a !default; // Selection Background
+$base03: #8f979b !default; // Comments, Invisibles, Line Highlighting
+$base04: #167b9c !default; // Dark Foreground (Used for status bars)
+$base05: #eceff1 !default; // Default Foreground, Caret, Delimiters, Operators
+$base06: #cfd8dc !default; // Light Foreground (Not often used)
+$base07: #2d4b5a !default; // Light Background (Not often used)
+$base08: #e33c54 !default; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+$base09: #ad23e2 !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
+$base0a: #e0b126 !default; // Classes, Markup Bold, Search Text Background
+$base0b: #69b81a !default; // Strings, Inherited Class, Markup Code, Diff Inserted
+$base0c: #20bfdf !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
+$base0d: #1ab2a4 !default; // Functions, Methods, Attribute IDs, Headings
+$base0e: #99b21a !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
+$base0f: #e28a33 !default; // Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>
 

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -62,8 +62,8 @@ $blockquote-color: $gray2; // $background-color;
 
 // Header
 $header-background-color: darken($theme-color, 50%); // Only used when no header image
-$header-text-color: $gray6;
-$header-link-color: $theme-color;
+$header-text-color: $gray8;
+$header-link-color: $gray6;
 $navbar-separator-opacity: 0;
 
 // Feature image for articles

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -50,7 +50,7 @@ $pink:    #ff66c2 !default;
 // Brand colors
 $theme-color: #569bd2;
 $brand-color: $gray0;
-$background-color: $gray1;
+$background-color: $gray0;
 $border-color: rgba(0, 0, 0, 0.1); // rgba recommended if using feature images
 
 // Typography colors

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -1,3 +1,4 @@
+/* GENERAL */
 // Typography
 $font-family-main: 'Source Sans Pro', Helvetica, Arial, sans-serif;
 $font-family-headings: 'Source Sans Pro', Helvetica, Arial, sans-serif;
@@ -11,7 +12,7 @@ $padding-medium: 6%;
 $padding-small: 4%;
 $padding-x-small: 3%;
 
-// Sepcific Padding
+// Specific Padding
 $title-padding: 1%;
 $feature-image-padding: 10%;
 
@@ -23,62 +24,110 @@ $break: 768px;
 $sm-break: 576px;
 $x-sm-break: 300px;
 
-// base16 Supernova
-$base00: #373e47 !default; // Default Background
-$base01: #444c56 !default; // Lighter Background (Used for status bars, line number and folding marks)
-$base02: #545d68 !default; // Selection Background
-$base03: #909dab !default; // Comments, Invisibles, Line Highlighting
-$base04: #adbac7 !default; // Dark Foreground (Used for status bars)
-$base05: #cdd9e5 !default; // Default Foreground, Caret, Delimiters, Operators
-$base06: #e7f3f4 !default; // Light Foreground (Not often used)
-$base07: #f2feff !default; // Light Background (Not often used)
-$base08: #d40059 !default; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
-$base09: #ff5c00 !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
-$base0a: #d9b600 !default; // Classes, Markup Bold, Search Text Background
-$base0b: #6bac00 !default; // Strings, Inherited Class, Markup Code, Diff Inserted
-$base0c: #00a8e0 !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
-$base0d: #b37eff !default; // Functions, Methods, Attribute IDs, Headings
-$base0e: #00af9e !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
-$base0f: #ff66c2 !default; // Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>
+/* COLOUR SCHEME */
+// Supernova Theme
+$gray0:   #22272e !default;
+$gray1:   #2d333b !default;
+$gray2:   #373e47 !default;
+$gray3:   #444c56 !default;
+$gray4:   #545d68 !default;
+$gray5:   #909dab !default;
+$gray6:   #adbac7 !default;
+$gray7:   #cdd9e5 !default;
+$gray8:   #e7f3f4 !default;
+$gray9:   #fff    !default;
+$red:     #d40059 !default;
+$orange:  #ff5c00 !default;
+$yellow:  #d9b600 !default;
+$green:   #6bac00 !default;
+$blue:    #00a8e0 !default;
+$magenta: #b37eff !default;
+$cyan:    #00af9e !default;
+$pink:    #ff66c2 !default;
 
-// Default colors
-$base0: #22272e  !default; // Darker background
-$base1: #2d333b  !default; // Lighter background
-$base2: #569bd2  !default; // Theme color
-
-// Brand colours
-$theme-color: #337ab7;
-$brand-color: #fff;
-$background-color: #fff;
+/* DARK MODE */
+/*
+// Brand colors
+$theme-color: #569bd2;
+$brand-color: $gray0;
+$background-color: $gray1;
 $border-color: rgba(0, 0, 0, 0.1); // rgba recommended if using feature images
 
-// Typography colours
-$text-color: #262626;
-$meta: #595959; //lowest gray for accessible color
+// Typography colors
+$text-color: $gray7;
+$meta: $gray5; //lowest gray for accessible color
 $link-color: $theme-color;
-$selection-color: #D4D4D4; // visible when highlighting text
-$blockquote-color: #EEF7FA; // $background-color;
+$selection-color: $gray4; // visible when highlighting text
+$blockquote-color: $gray2; // $background-color;
 
 // Header
 $header-background-color: darken($theme-color, 50%); // Only used when no header image
-$header-text-color: #fff;
-$header-link-color: #383838;
+$header-text-color: $gray6;
+$header-link-color: $theme-color;
 $navbar-separator-opacity: 0;
 
 // Feature image for articles
-$feature-image-text-color: #fff;
+$feature-image-text-color: $gray9;
 $feature-image-size: cover; // options include "cover", "contain", "auto"
 
-//Search colours
+// Search colors
 $link-shadow: transparentize($link-color, .6); //rgba(26, 188, 156, 0.6);
-$text-shadow: #3f3f3f;
-$search-color: #999;
+$text-shadow: $gray1;
+$search-color: $gray6;
+*/
 
+/* Light Mode (Default) */
+// Brand colors
+$theme-color: #337ab7 !default;
+$brand-color: $gray9 !default;
+$background-color: $gray9 !default;
+$border-color: rgba(0, 0, 0, 0.1) !default; // rgba recommended if using feature images
 
-/*  Syntax highlighting  */
-// Syntax typography
+// Typography colors
+$text-color: #262626 !default;
+$meta: #595959 !default; //lowest gray for accessible color
+$link-color: $theme-color !default;
+$selection-color: #D4D4D4 !default; // visible when highlighting text
+$blockquote-color: #EEF7FA !default; // $background-color;
+
+// Header
+$header-background-color: darken($theme-color, 50%) !default; // Only used when no header image
+$header-text-color: $gray9 !default;
+$header-link-color: #383838 !default;
+$navbar-separator-opacity: 0 !default;
+
+// Feature image for articles
+$feature-image-text-color: $gray9 !default;
+$feature-image-size: cover !default; // options include "cover", "contain", "auto"
+
+// Search colors
+$link-shadow: transparentize($link-color, .6) !default; //rgba(26, 188, 156, 0.6);
+$text-shadow: #3f3f3f !default;
+$search-color: #999 !default;
+
+/* SYNTAX HIGHLIGHTING  */
+// Typography
 $monospace: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, sans-serif !default;
 $font-size-code: 0.85em !default;
 $font-height-code: 1.3em !default;
 $border-radius: 4px !default;
+
+// Colors
+// base16 Supernova
+$base00: $gray2;   // Default Background
+$base01: $gray3;   // Lighter Background (Used for status bars, line number and folding marks)
+$base02: $gray4;   // Selection Background
+$base03: $gray5;   // Comments, Invisibles, Line Highlighting
+$base04: $gray6;   // Dark Foreground (Used for status bars)
+$base05: $gray7;   // Default Foreground, Caret, Delimiters, Operators
+$base06: $gray8;   // Light Foreground (Not often used)
+$base07: $gray9;   // Light Background (Not often used)
+$base08: $red;     // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+$base09: $orange;  // Integers, Boolean, Constants, XML Attributes, Markup Link Url
+$base0a: $yellow;  // Classes, Markup Bold, Search Text Background
+$base0b: $green;   // Strings, Inherited Class, Markup Code, Diff Inserted
+$base0c: $blue;    // Support, Regular Expressions, Escape Characters, Markup Quotes
+$base0d: $magenta; // Functions, Methods, Attribute IDs, Headings
+$base0e: $cyan;    // Keywords, Storage, Selector, Markup Italic, Diff Changed
+$base0f: $pink;    // Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>
 

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -23,6 +23,29 @@ $break: 768px;
 $sm-break: 576px;
 $x-sm-break: 300px;
 
+// base16 Supernova
+$base00: #373e47 !default; // Default Background
+$base01: #444c56 !default; // Lighter Background (Used for status bars, line number and folding marks)
+$base02: #545d68 !default; // Selection Background
+$base03: #909dab !default; // Comments, Invisibles, Line Highlighting
+$base04: #adbac7 !default; // Dark Foreground (Used for status bars)
+$base05: #cdd9e5 !default; // Default Foreground, Caret, Delimiters, Operators
+$base06: #e7f3f4 !default; // Light Foreground (Not often used)
+$base07: #f2feff !default; // Light Background (Not often used)
+$base08: #d40059 !default; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+$base09: #ff5c00 !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
+$base0a: #d9b600 !default; // Classes, Markup Bold, Search Text Background
+$base0b: #6bac00 !default; // Strings, Inherited Class, Markup Code, Diff Inserted
+$base0c: #00a8e0 !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
+$base0d: #b37eff !default; // Functions, Methods, Attribute IDs, Headings
+$base0e: #00af9e !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
+$base0f: #ff66c2 !default; // Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>
+
+// Default colors
+$base0: #22272e  !default; // Darker background
+$base1: #2d333b  !default; // Lighter background
+$base2: #569bd2  !default; // Theme color
+
 // Brand colours
 $theme-color: #337ab7;
 $brand-color: #fff;
@@ -58,62 +81,4 @@ $monospace: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu San
 $font-size-code: 0.85em !default;
 $font-height-code: 1.3em !default;
 $border-radius: 4px !default;
-
-/*
-// base16 Material Theme
-$base00: #302f2d !default; // Default Background
-$base01: #2E3C43 !default; // Lighter Background (Used for status bars) - NOT USED
-$base02: #314549 !default; // Selection Background - NOT USED
-$base03: #546E7A !default; // Dark Foreground (Used for status bars) - NOT USED
-$base04: #B2CCD6 !default; // Comments, Invisible, Line Highlighting
-$base05: #EEFFFF !default; // Light Foreground (Not often used)
-$base06: #EEFFFF !default; // Light Background (Not often used)
-$base07: #FFFFFF !default; // Default Foreground, Default text color
-$base08: #F07178 !default; // Parenthesis, Caret, Delimiters, Operators
-$base09: #F78C6C !default; // Classes, Markup Bold, Search Text Background
-$base0a: #FFCB6B !default; // Strings, Inherited Class, Markup Code, Diff Inserted
-$base0b: #98C379 !default; // Functions, Methods, Attribute IDs, Headings
-$base0c: #89DDFF !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
-$base0d: #82AAFF !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
-$base0e: #C792EA !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
-$base0f: #FF5370 !default; // Deprecated, Opening/Closing Embedded Language Tags e.g.
-*/
-
-/*
-// base16 Monokai
-$base00: #272822 !default; // Default Background
-$base01: #383830 !default; // Lighter Background (Used for status bars)
-$base02: #49483e !default; // Selection Background
-$base03: #75715e !default; // Dark Foreground (Used for status bars)
-$base04: #a59f85 !default; // Comments, Invisible, Line Highlighting
-$base05: #f8f8f2 !default; // Light Foreground (Not often used)
-$base06: #f5f4f1 !default; // Light Background (Not often used)
-$base07: #f9f8f5 !default; // Default text color
-$base08: #f92672 !default; // Parenthesis, Caret, Delimiters, Operators
-$base09: #fd971f !default; // Classes, Markup Bold, Search Text Background
-$base0a: #e6db74 !default; // Strings, Inherited Class, Markup Code, Diff Inserted
-$base0b: #a6e22e !default; // Functions, Methods, Attribute IDs, Headings
-$base0c: #a1efe4 !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
-$base0d: #66d9ef !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
-$base0e: #ae81ff !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
-$base0f: #cc6633 !default; // Deprecated, Opening/Closing Embedded Language Tags e.g.
-*/
-
-// base16 Nebula
-$base00: #2a373d !default; // Default Background
-$base01: #334046 !default; // Lighter Background (Used for status bars, line number and folding marks)
-$base02: #1b252a !default; // Selection Background
-$base03: #8f979b !default; // Comments, Invisibles, Line Highlighting
-$base04: #167b9c !default; // Dark Foreground (Used for status bars)
-$base05: #eceff1 !default; // Default Foreground, Caret, Delimiters, Operators
-$base06: #cfd8dc !default; // Light Foreground (Not often used)
-$base07: #2d4b5a !default; // Light Background (Not often used)
-$base08: #e33c54 !default; // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
-$base09: #ad23e2 !default; // Integers, Boolean, Constants, XML Attributes, Markup Link Url
-$base0a: #e0b126 !default; // Classes, Markup Bold, Search Text Background
-$base0b: #69b81a !default; // Strings, Inherited Class, Markup Code, Diff Inserted
-$base0c: #20bfdf !default; // Support, Regular Expressions, Escape Characters, Markup Quotes
-$base0d: #1ab2a4 !default; // Functions, Methods, Attribute IDs, Headings
-$base0e: #99b21a !default; // Keywords, Storage, Selector, Markup Italic, Diff Changed
-$base0f: #e28a33 !default; // Deprecated, Opening/Closing Embedded Language Tags, e.g. <?php ?>
 

--- a/_sass/external/font-awesome/_stacked.scss
+++ b/_sass/external/font-awesome/_stacked.scss
@@ -27,5 +27,5 @@
 }
 
 .#{$fa-css-prefix}-inverse {
-  color: $fa-inverse;
+  color: $background-color;
 }

--- a/_sass/includes/_footer.scss
+++ b/_sass/includes/_footer.scss
@@ -4,7 +4,7 @@
   display: inline-block;
   text-align: center;
   width: 100%;
-  color: lighten($text-color, 24%);
+  color: $meta;
   font-size: 0.9em;
 
   .footer-icons {

--- a/_sass/includes/_footer.scss
+++ b/_sass/includes/_footer.scss
@@ -15,6 +15,10 @@
       li {
         display: inline;
       }
+    
+      a {
+        color: $gray5;
+      }
 
       a:hover {
         color: darken($link-color, 15%);

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -134,3 +134,10 @@ header {
     background-size: 400% auto;
   }
 }
+
+.post-content {
+  h2 { color: $red; }
+  h3 { color: $magenta; }
+  h4 { color: $cyan; }
+  h5 { color: $green; }
+}

--- a/_sass/type-on-strap.scss
+++ b/_sass/type-on-strap.scss
@@ -1,11 +1,11 @@
+// Variables
+@import 'base/variables';
 // External
 @import 'external/reset';
 @import 'external/font-awesome';
 @import 'external/pacifico';
 @import 'external/katex';
 @import 'external/source-sans-pro';
-// Variables
-@import 'base/variables';
 // Base
 @import 'base/global';
 @import 'base/highlight';


### PR DESCRIPTION
I made it so the original Light theme is default and Dark Theme is enabled by uncommenting the respective section on `/_sass/_base/_variables.scss`. I don't know if there's way to put it on `_config.yml`. I also created a color pallete and changed the highlighting theme. IDK if you interested on having that feature on the theme. I made it for my blog.
