### PR TITLE
Style updates for dark mode headers

### DIFF
--- a/_posts/2021-04-27-dark-mode.md
+++ b/_posts/2021-04-27-dark-mode.md
@@ -1,0 +1,107 @@
+---
+layout: post
+title: Dark Mode 
+---
+
+**More colors with less light.**
+
+Click the half-moon most top-right button to turn the lights on/off. 
+
+# Headers
+## Level 2
+### Level 3
+#### Level 4
+##### Level 5
+###### Level 6
+ 
+# [Headers with links](http://localhost)
+## [Level 2](http://localhost)
+### [Level 3](http://localhost)
+#### [Level 4](http://localhost)
+##### [Level 5](http://localhost) 
+###### [Level 6](http://localhost)
+
+
+# Code highlight
+Mode specific code highlighting themes.
+
+```python
+#!/usr/bin/env python
+"""
+Test file for Python syntax highlighting in editors / IDEs.
+Meant to cover a wide range of different types of statements and expressions.
+Not necessarily sensical or comprehensive (assume that if one exception is
+highlighted that all are, for instance).
+Extraneous trailing whitespace can't be tested because of svn pre-commit hook
+checks for such things.
+
+@author: pshchelo
+@source: https://gist.github.com/pshchelo/8e2784ef5304df57d2b6322de5a56dc9
+"""
+# Comment
+# OPTIONAL: XXX catch your attention
+# TODO(me): next big thing
+# FIXME: this does not work
+
+# Statements
+from __future__ import with_statement  # Import
+from sys import path as thing
+
+print(thing)
+
+assert True  # keyword
+
+
+def foo():  # function definition
+    return []
+
+
+class Bar(object):  # Class definition
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args):
+        pass
+
+foo()  # UNCOLOURED: function call
+while False:  # 'while'
+    continue
+for x in foo():  # 'for'
+    break
+with Bar() as stuff:
+    pass
+if False:
+    pass  # 'if'
+elif False:
+    pass
+else:
+    pass
+
+# Constants
+'single-quote', u'unicode'  # Strings of all kinds; prefixes not highlighted
+"double-quote"
+"""triple double-quote"""
+'''triple single-quote'''
+r'raw'
+ur'unicode raw'
+'escape\n'
+'\04'  # octal
+'\xFF'  # hex
+'\u1111'  # unicode character
+1  # Integral
+1L
+1.0  # Float
+.1
+1+2j  # Complex
+
+# Expressions
+1 and 2 or 3  # Boolean operators
+2 < 3  # UNCOLOURED: comparison operators
+spam = 42  # UNCOLOURED: assignment
+2 + 3  # UNCOLOURED: number operators
+[]  # UNCOLOURED: list
+{}  # UNCOLOURED: dict
+(1,)  # UNCOLOURED: tuple
+all  # Built-in functions
+GeneratorExit  # Exceptions
+```

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -95,10 +95,12 @@ html, html[data-theme="light"] {
   --code-inline: #24292e;
   --text-shadow: #3f3f3f;
   --text: #262626;
+  --h1: #262626;
   --h2: #262626;
   --h3: #262626;
   --h4: #262626;
   --h5: #262626;
+  --h6: #262626;
   --border: rgba(0, 0, 0, 0.1);
 }
 
@@ -115,9 +117,11 @@ html[data-theme="dark"] {
   --code-inline: #d9b600;
   --text-shadow: #2d333b; // text shadow
   --text: #cdd9e5; // text
-  --h2: #d40059;
+  --h1: #d40059; // headers
+  --h2: #b37eff;
   --h3: #ff66c2;
   --h4: #00af9e;
   --h5: #6bac00;
+  --h6: #ff5c00;
   --border: rgba(0, 0, 0, 0.1); // border
 }

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -137,8 +137,19 @@ header {
 }
 
 .post-content {
-  h2 { color: var(--h2); }
-  h3 { color: var(--h3); }
-  h4 { color: var(--h4); }
-  h5 { color: var(--h5); }
+  h1 { color: var(--h1) !important; }
+  h2 { color: var(--h2) !important; }
+  h3 { color: var(--h3) !important; }
+  h4 { color: var(--h4) !important; }
+  h5 { color: var(--h5) !important; }
+  h6 { color: var(--h6) !important; }
+
+  a {
+    color: inherit;
+    filter: hue-rotate(20deg);
+
+    :visited {
+      filter: saturate(0.7);  
+    }
+  }
 }

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -137,12 +137,12 @@ header {
 }
 
 .post-content {
-  h1 { color: var(--h1) !important; }
-  h2 { color: var(--h2) !important; }
-  h3 { color: var(--h3) !important; }
-  h4 { color: var(--h4) !important; }
-  h5 { color: var(--h5) !important; }
-  h6 { color: var(--h6) !important; }
+  h1 { color: var(--h1); }
+  h2 { color: var(--h2); }
+  h3 { color: var(--h3); }
+  h4 { color: var(--h4); }
+  h5 { color: var(--h5); }
+  h6 { color: var(--h6); }
 
   a {
     color: inherit;


### PR DESCRIPTION
- Color from h1 to h6 (before was h2 to h5)
- Inherit colors for headers with links
- Apply a slight hue transform for headers with links
- Desaturate colors for visited links
