### PR TITLE
add utterances

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ cookie_consent: false               # To respect the usage of cookies
 
 # Set which comment system to use
 comments:
-  # 'disqus' or 'utterances' are available
+  # 'disqus' or 'cusdis' or also 'utterances' are available
   provider:            #utterances # or disqus or cusdis
   
   

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,24 @@ color_image: /assets/img/lineart.png                    # A bit transparent for 
 katex: true                                             # Enable if using math markup
 mermaid: true                                           # Enable mermaid-js for sequence and diagrams
 google_analytics:                                       # Tracking ID, e.g. "UA-000000-01"
-cookie_consent: false                                   # To respect the usage of cookies
+cookie_consent: false               # To respect the usage of cookies
+
+# Set which comment system to use
+comments:
+  # 'disqus' or 'utterances' are available
+  provider:            #utterances # or disqus or cusdis
+  
+  
+# You must install utterances github app before use.(https://github.com/apps/utterances)
+# Make sure all variables are set properly. Check below link for detail.
+# https://utteranc.es/
+utterances:
+  repo:                "sylhare/Type-on-Strap"
+  issue-term:          "pathname"
+  label:               "Comments"
+  theme:               "dark-blue"
+  
+  
 disqus_shortname:                                       # Your discus shortname for comments
 cusdis_app_id:                                          # Your cusdis data-app-id
 color_theme: auto                                       # auto, dark or light

--- a/_config.yml
+++ b/_config.yml
@@ -36,8 +36,11 @@ comments:
 # You must install utterances github app before use.(https://github.com/apps/utterances)
 # Make sure all variables are set properly. Check below link for detail.
 # https://utteranc.es/
+# for your information, 
+# utterances is open source and free.
+# no ads at all where disqus provides ads and no permission needed when you are using cusdis
 utterances:
-  repo:                "sylhare/Type-on-Strap"
+  repo:                "[your repo name here]"
   issue-term:          "pathname"
   label:               "Comments"
   theme:               "dark-blue"

--- a/_includes/social/utterances.html
+++ b/_includes/social/utterances.html
@@ -1,0 +1,7 @@
+<script src="https://utteranc.es/client.js"
+        repo="sylhare/Type-on-Strap"
+        issue-term="pathname"
+        theme="dark"
+        crossorigin="anonymous"
+        async>
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,6 +44,9 @@ layout: default
 {% if site.disqus_shortname or site.theme_settings.disqus_shortname %}
 {% include social/disqus.html %}{% endif %}
 
+<!--utterances-->
+{% if site.utterances %}{% include social/utternaces.html %}{% endif %}
+
 <!-- To change color of links in the page -->
 <style>
   header#main {

--- a/_posts/2013-10-18-blogging-with-title.md
+++ b/_posts/2013-10-18-blogging-with-title.md
@@ -3,6 +3,7 @@ layout: post
 title: >
     Blogging with title 
 tags: [Test, Ipsum, Markdown, Portfolio]
+comments: true
 ---
 
 # I am a BIG title


### PR DESCRIPTION
So, people who know this know that Disqus is full of ads if you use it for free, and Cusdis might nag people like me for permission. So, I found out about Utterances, another chat system and it is open source, and uses GitHub login. I am trying to add it here. There has to be a mistake. If you find it, please change it.

Changes made to files:
config.yml: added utterances permission code and a whole new set of code to choose the comment system.

New files:
utterances.html ~~~> here has to be a mistake, please change it