### PR TITLE
Added "language switcher" to navbar (for polyglot plugin)

### DIFF
--- a/_includes/default/navbar.html
+++ b/_includes/default/navbar.html
@@ -35,10 +35,19 @@
             {% assign name_page = page.title | append: name_page %}
         {% endfor %}
         
+        <!-- Light/Dark mode switcher -->
         {% if site.color_theme == 'auto' %}
         <li class="separator"> | </li>
-        <li><a id="theme-toggle" title="{{ page.title }} " aria-label="{{ page.title }}" onclick="themeToggle()"></a></li>
+        <li><a id="theme-toggle" title="{{ page.title }} "aria-label="{{ page.title }}" onclick="themeToggle()"></a></li>
         {% endif %}
+
+        <!-- Language switcher -->
+        {% for lang in site.languages %}
+            <li class="separator"> | </li>
+            <li>
+                <a {% if lang == site.active_lang %}style="font-weight: bold;"{% endif %} href="{% if lang == site.default_lang %} {{ site.baseurl }}{{ page.url }} {% else %} {{ site.baseurl }}/{{ lang }}{{ page.url }} {% endif %}">{{ site.data.lang-names[lang] }}</a>
+            </li>
+        {% endfor %}
     </ul>
 
 	</nav>


### PR DESCRIPTION
## Optional language switcher for navbar in mulitlingual sites

I added a simple "language switcher" to the navbar&mdash;to be used in conjunction with the [polyglot plugin](https://github.com/untra/polyglot).

The language names to be displayed can be configured in `_data/lang-names.yml`, for example, if I had configured the polyglot plugin to use the following languages: `languages: ["en", "de", "zh-Hant", "zh-Hans"]`, I could add the following to `_data/lang-names.yml`:

```
en: "English"
de: "Deutsch"
zh-Hant: "繁體中文"
zh-Hans: "简体中文"
```

If one doesn't have polyglot installed or doesn't have a file called `_data/lang-names.yml`, it won't do anything&mdash;at least as far as I know&mdash;so it probably would remain *unintrusive* to anyone who doesn't need or want a multilingual site.

What do you think of this idea? 

Next I'll try to find a way to make other site elements multilingual&mdash;such as header/footer text, dates, site title etc. If it turns out that this could be useful to anyone, I can also submit it here.

