### PR TITLE
Added the means to localise the date format

### DIFF
--- a/_data/language.yml
+++ b/_data/language.yml
@@ -18,3 +18,4 @@ str_months: [January, February, March, April, May, June, July, August, September
 
 # Localization settings 
 cusdis_lang: # zh-cn, es, tr, pt-BR
+date_format: "%B %d, %Y"

--- a/_includes/blog/post_info.html
+++ b/_includes/blog/post_info.html
@@ -1,4 +1,5 @@
 {% assign author = site.data.authors[include.author] %}
+{% assign date_format = site.data.language.date_format %}
 {% assign date = include.date | default: "today" | date: "%B %-d, %Y" %}
 
 <div class="post-info">
@@ -8,8 +9,12 @@
     {% endif %}
     <p class="meta">
       {% if author.name %}{{ author.name }} - {% endif %}
+
       {% assign x = date | date: "%m" | minus: 1 %}
-      {{ site.data.language.str_months[x] | default: date | date: "%B" }} {{ date | date: "%d, %Y" }}
+      {% assign month_str = site.data.language.str_months[x] | default: date | date: "%B" %} 
+      {% assign date_format = date_format | default: "%B %d, %Y" | replace: "%B", month_str %}
+    
+      {{ date | date: date_format }}
     </p>
   {%- if author.url -%}</a>{%- endif -%}
 </div>


### PR DESCRIPTION
The date format can be defined in `language.yml`, e.g. `date_format: "%B %d, %Y"`.

If one is using the polyglot plugin to build a multilingual site, one can place a `language.yml` file each into a separate directory for each language in `_data`, e.g. `_data/en/language.yml`, `_data/de/language.yml`&mdash;polyglot will automatically fetch the date_format (as well as all the other strings) according to the currently selected language.

If one doesn't do anything or doesn't add `date_format: <date-format-string>` to `language.yml`, the dates will&mdash;per default&mdash;show the same way they previously have been showing in this theme.