### PR TITLE
fix bug on pre for mail icon

### DIFF
--- a/_data/icons_builder.yml
+++ b/_data/icons_builder.yml
@@ -29,7 +29,7 @@ keybase:
 linkedin:
   pre: "https://www.linkedin.com/in/"
 mail:
-  pre: "mailto://"
+  pre: "mailto:"
   icon: "fas fa-envelope"
 map:
   pre: "https://www.openstreetmap.org/#map=15/"


### PR DESCRIPTION
Correct pre for mail should be "mailto:" without ending with "//"
```
mail:
  pre: "mailto:"
```

<a href="https://gitpod.io/#https://github.com/sylhare/Type-on-Strap/pull/323"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

