### PR TITLE
Update gitpod with bundle

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,11 +1,11 @@
-# Now, on every start of a workspace.
+# Documentation: https://www.gitpod.io/docs/references/gitpod-yml
 image: gitpod/workspace-full
 
 # Task(s)
 tasks:
   - before: |
       gem install bundle
-      bundle config set --local deployment 'true'
+      bundle config set --local path 'vendor/bundle'
     init: |
       bundle update
       bundle install

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,13 +3,15 @@ image: gitpod/workspace-full
 
 # Task(s)
 tasks:
-  - before: gem install bundle
-    init: | 
+  - before: |
+      gem install bundle
+      bundle config set --local deployment 'true'
+    init: |
       bundle update
       bundle install
-  - name: Jekyll server 
-    init: bundle install 
-    command: bundle exec jekyll serve 
+  - name: Run type on strap
+    init: bundle install
+    command: bundle exec jekyll serve
 
 # In case the user is trying to make a pull request, he needs GitLens, which by default is not installed. This code will help us install it.
 vscode:


### PR DESCRIPTION
Seems like when running `bundle install` in gitpod prebuild the installation does not stay cached.
It could be linked to the way [ruby is installed in the docker image](https://community.gitpod.io/t/how-to-properly-pre-install-gems-in-dockerfile/2698/2).

So I'll try to install locally and see if the changes are persisted.

<a href="https://gitpod.io/#https://github.com/sylhare/Type-on-Strap/pull/324"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

