### PR TITLE
Add mermaid color

### DIFF
--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -282,3 +282,13 @@ kbd {
   padding-top: 2em;
   max-width: 100%;
 }
+
+.actor, .labelBox {
+  fill: lighten($actor, 25%) !important;
+  stroke: $actor !important;
+}
+
+.note {
+  fill: lighten($note, 25%) !important;
+  stroke: $note !important;
+}

--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -269,26 +269,45 @@ kbd {
 }
 
 // Mermaid
+%mermaid-main-color {
+  fill: lighten($main, 25%) !important;
+  stroke: $main !important;
+}
+
 .mermaid {
   background-color: rgba(255, 255, 255, 0.9);
   border-radius: 2%;
-}
 
-.mermaid > svg {
-  margin: auto;
-  display: block;
-  height: auto;
-  padding-bottom: 2em;
-  padding-top: 2em;
-  max-width: 100%;
-}
+  text, tspan {
+    font-family: $font-family-main !important;
+  }
 
-.actor, .labelBox {
-  fill: lighten($actor, 25%) !important;
-  stroke: $actor !important;
-}
+  & > svg {
+    margin: auto;
+    display: block;
+    height: auto;
+    padding-bottom: 2em;
+    padding-top: 2em;
+    max-width: 100%;
+  }
 
-.note {
-  fill: lighten($note, 25%) !important;
-  stroke: $note !important;
+  .actor, .labelBox, .label-container {
+    @extend %mermaid-main-color
+  }
+
+  .classGroup {
+    rect, line {
+      @extend %mermaid-main-color
+    }
+  }
+
+  .note {
+    fill: lighten($secondary, 25%) !important;
+    stroke: $secondary !important;
+  }
+
+  .cluster rect {
+    fill: lighten($secondary, 40%) !important;
+    stroke: $secondary !important;
+  }
 }

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -28,8 +28,8 @@ $x-sm-break: 320px;
 
 /* MERMAID */
 // For better look, use light colour
-$actor: #ccccff;
-$note: #decc93;
+$main: #ccccff;
+$secondary: #decc93;
 
 /* THEME COLOR SCHEMES */
 html, html[data-theme="light"] {

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -26,6 +26,10 @@ $break: 768px;
 $sm-break: 576px;
 $x-sm-break: 320px;
 
+/* MERMAID */
+// For better look, use light colour
+$actor: #ccccff;
+$note: #decc93;
 
 /* THEME COLOR SCHEMES */
 html, html[data-theme="light"] {


### PR DESCRIPTION
To easily change the color of the mermaid diagrams.
The variable is for the stroke, then a 25% light color will be generated for the fill.

<a href="https://gitpod.io/#https://github.com/sylhare/Type-on-Strap/pull/325"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

