### PR TITLE
Fix responsive flag

### DIFF
--- a/_layouts/home.liquid
+++ b/_layouts/home.liquid
@@ -8,7 +8,7 @@ layout: default
         .call-out_img {
             background-image: url('{{ image | join: '.' }}');
         }
-        {% if header_feature_image_responsive %}
+        {% if site.header_feature_image_responsive %}
         @media screen and (max-width: 768px) {
             .call-out_img {
                 background-image: url('{{ image[0] | append: '-medium.' | append: image[1] | default: image}}');


### PR DESCRIPTION
Missing `site.` so it won't use the responsive image even when set to `true`

<a href="https://gitpod.io/#https://github.com/sylhare/Type-on-Strap/pull/334"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

