### PR TITLE
Replace git ls-files with Dir

### DIFF
--- a/type-on-strap.gemspec
+++ b/type-on-strap.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files        = %w(README.md LICENSE)
   spec.metadata["plugin_type"] = "theme"
 
-  spec.files                   = `git ls-files -z`.split("\x0").select do |f|
+  spec.files                   = Dir["**/*"].select do |f|
     f.match(%r!^(assets/(js|css|fonts|data)/|_(includes|layouts|sass)/|_data/(icons_builder.yml|language.yml)|(LICENSE|README.md))!i)
   end
 


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
This PR replaces environment-dependent `git ls-files -z` with pure ruby implementation `Dir[“**/*”]`.

Fixes #360 


<a href="https://gitpod.io/#https://github.com/sylhare/Type-on-Strap/pull/361"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

