### PR TITLE
Bump ruby supported version

### DIFF
--- a/.github/workflows/gem-build.yml
+++ b/.github/workflows/gem-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ '2.6', '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/type-on-strap.gemspec
+++ b/type-on-strap.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                                Thanks for using Type on strap v2+!
                                MSG
 
-  spec.required_ruby_version   = '>= 2.4.0'
+  spec.required_ruby_version   = '>= 2.7.0'
 
   spec.add_runtime_dependency "jekyll", ">= 3.8", "< 5.0"
   spec.add_runtime_dependency "jekyll-feed", ">= 0.15.1", "<= 0.17"


### PR DESCRIPTION
From `2.4` to `2.7` to follow up with #366 


<a href="https://gitpod.io/#https://github.com/sylhare/Type-on-Strap/pull/367"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

