### PR TITLE
Change the filter to the correct order

### DIFF
--- a/_includes/default/head.liquid
+++ b/_includes/default/head.liquid
@@ -83,7 +83,7 @@
 
     <!-- Twitter Cards -->
     <meta name="twitter:title" content="{{ page.title | default: site.title }}">
-    <meta name="twitter:description" content="{{ page.content | strip_html | strip_newlines | truncate: 160 | default: site.header_text}}">
+    <meta name="twitter:description" content="{{ page.content | default: site.header_text | strip_html | strip_newlines | truncate: 160 }}">
     {% if site.data.social.twitter %}
     <meta name="twitter:creator" content="@{{ site.data.social.twitter }}">
     <meta name="twitter:site" content="@{{ site.data.social.twitter }}">


### PR DESCRIPTION
### Description
This PR corrects the order of the filter of `content` property inside `twitter:description` `meta` tag.

Closes #398 

### Screenshot
![image](https://github.com/sylhare/Type-on-Strap/assets/45678482/b4d72dfa-721b-4f4d-ab03-7b84b5b81ded)

![image](https://github.com/sylhare/Type-on-Strap/assets/45678482/bd684a59-fbc3-4816-86f2-29f4b6f1f93e)

### Testing Instructions
1. Change `header_text` to multi-line content with HTML tags
2. Check the `twitter:description` `meta` tag at homepage, the HTML tags should be stripped and not overflowed to `body`
3. Check the `twitter:description` `meta` tag at any posts, the behavior should be identical as before