### PR TITLE
Fix sass deprecation warning

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         docker run \
         -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
+        sylhare/jekyll:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
 
     - name: Install packages
       continue-on-error: true

--- a/_sass/includes/_share_buttons.scss
+++ b/_sass/includes/_share_buttons.scss
@@ -1,6 +1,8 @@
+@use "sass:math";
+
 ul.share-buttons {
   list-style: none;
-  padding: $padding-x-small/2 0 $padding-x-small/4 0;
+  padding: math.div($padding-x-small, 2) 0 math.div($padding-x-small, 4) 0;
   margin: 0;
   text-align: center;
 

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .comments {
   @extend %padding-post;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
@@ -99,7 +101,7 @@ header {
   header {
     color: var(--header-text);
     margin-bottom: 0;
-    padding: $padding-large/2.5 $padding-large;
+    padding: math.div($padding-large, 2.5) $padding-large;
 
     .meta {
       color: var(--header-text);


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
When starting type-on-strap there's deprecation warning for a sass division:

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($padding-x-small, 2) or calc($padding-x-small / 2)
```

Applying the recommendation.
