### PR TITLE
Update sass fix to work with github-pages deprecated sass converter

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -10,18 +10,22 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Do not change as jekyll/builder is used by GitHub pages (for compatibility)
+        docker-image: [ 'jekyll/builder', 'sylhare/jekyll' ]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the site in the jekyll/builder container
-      run: |
-        docker run \
-        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        sylhare/jekyll:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
+      - uses: actions/checkout@v3
+      - name: Build the site in the container
+        run: |
+          docker run \
+          -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+          ${{ matrix.docker-image }}:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
 
-    - name: Install packages
-      continue-on-error: true
-      run: |
-        docker pull sylhare/type-on-strap
-        docker pull sylhare/jekyll
+      - name: Install packages
+        continue-on-error: true
+        run: |
+          docker pull sylhare/type-on-strap
+          docker pull sylhare/jekyll
 

--- a/_sass/includes/_share_buttons.scss
+++ b/_sass/includes/_share_buttons.scss
@@ -1,8 +1,6 @@
-@use "sass:math";
-
 ul.share-buttons {
   list-style: none;
-  padding: math.div($padding-x-small, 2) 0 math.div($padding-x-small, 4) 0;
+  padding: 1.5% 0 0.75% 0;
   margin: 0;
   text-align: center;
 

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 .comments {
   @extend %padding-post;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
@@ -101,7 +99,7 @@ header {
   header {
     color: var(--header-text);
     margin-bottom: 0;
-    padding: math.div($padding-large, 2.5) $padding-large;
+    padding: 3.6% $padding-large;
 
     .meta {
       color: var(--header-text);


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
The GitHub pages gem is using an old (and deprecated) version of the sass converter which does not have the `@use` in it (v1.5.2) so I removing it and hard-coding the value for now, since the previous notation was being deprecated.