### PR TITLE
Improve search file

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,10 +502,12 @@ gallery: "assets/img/pexels"
 
 The search feature is based on [Simple-Jekyll-search](https://github.com/christian-fei/Simple-Jekyll-Search) 
 there is a `search.liquid` file that will create a list of all the site posts, pages and portfolios. 
+Then there's a script displaying the formatted results in the _search page_.
 
-Then there's a `search.js` displaying the formatted results in the "search" page.
-
-The search page can be hidden with the `hide` option. You can remove the icon by removing `icon`:
+To exclude contents from the search add the `exclude: true` option in the markdown header. 
+By default, all posts, pages, and collections are available in the search.
+Hide the search page from the navigation bar with the `hide: true` option. 
+You can remove the icon by removing `icon`:
 
 ```yml
 

--- a/_includes/default/search_input.liquid
+++ b/_includes/default/search_input.liquid
@@ -26,18 +26,21 @@
     {% endunless %}
     }{% unless forloop.last %},{% endunless %}
 {% endfor %}
-{% if site.portfolio.size > 0 %},{% endif %}
-{% for page in site.portfolio %}
-    {
-    {% if page.excluded or page.title != nil %}
-        "title"    : "{{ page.title | strip_newlines | escape }}",
-        "category" : "{{ page.category }}",
-        "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
-        "url"      : "{{ page.url | relative_url }}",
-        "date"     : "{{ page.date | date: "%B %-d, %Y" | default: "N/A" }}",
-        "excerpt"  : {{ page.content | strip_html | strip_newlines | strip | escape | truncate: '250' | jsonify }},
-        "content"  : {{ page.content | strip_html | strip_newlines | strip | escape | jsonify }}
-    {% endif %}
-    } {% unless forloop.last %},{% endunless %}
+{% if site.collections.size > 0 %},{% endif %}
+{% for collection in site.collections %}
+    {% for page in site[collection.label] %}
+        {
+        {% if page.excluded or page.title != nil %}
+            "title"    : "{{ page.title | strip_newlines | escape }}",
+            "category" : "{{ page.category }}",
+            "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
+            "url"      : "{{ page.url | relative_url }}",
+            "date"     : "{{ page.date | date: "%B %-d, %Y" | default: "N/A" }}",
+            "excerpt"  : {{ page.content | strip_html | strip_newlines | strip | escape | truncate: '250' | jsonify }},
+            "content"  : {{ page.content | strip_html | strip_newlines | strip | escape | jsonify }}
+        {% endif %}
+        }{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    {% unless forloop.last %},{% endunless %}
 {% endfor %}
 ]

--- a/_includes/default/search_input.liquid
+++ b/_includes/default/search_input.liquid
@@ -1,19 +1,21 @@
 [
 {% for post in site.posts %}
     {
-    "title"    : "{{ post.title | strip_newlines | escape }}",
-    "category" : "{{ post.category }}",
-    "tags"     : "{{ post.tags | join: ', ' | prepend: " " }}",
-    "url"      : "{{ post.url | relative_url }}",
-    "date"     : "{{ post.date | date: "%B %-d, %Y" }}",
-    "excerpt"  : {{ post.content | strip_html | strip_newlines | strip | escape | truncate: '250' | escape | jsonify }},
-    "content"  : {{ post.content | strip_html | strip_newlines | strip | escape | jsonify }}
+    {% unless post.excluded %}
+        "title"    : "{{ post.title | strip_newlines | escape }}",
+        "category" : "{{ post.category }}",
+        "tags"     : "{{ post.tags | join: ', ' | prepend: " " }}",
+        "url"      : "{{ post.url | relative_url }}",
+        "date"     : "{{ post.date | date: "%B %-d, %Y" }}",
+        "excerpt"  : {{ post.content | strip_html | strip_newlines | strip | escape | truncate: '250' | escape | jsonify }},
+        "content"  : {{ post.content | strip_html | strip_newlines | strip | escape | jsonify }}
+    {% endunless %}
     }{% unless forloop.last %},{% endunless %}
 {% endfor %}
 {% if site.pages.size > 0 %},{% endif %}
 {% for page in site.pages %}
     {
-    {% unless page.hide or page.title == nil %}
+    {% unless page.excluded or page.title == nil %}
         "title"    : "{{ page.title | strip_newlines | escape }}",
         "category" : "{{ page.category }}",
         "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
@@ -27,7 +29,7 @@
 {% if site.portfolio.size > 0 %},{% endif %}
 {% for page in site.portfolio %}
     {
-    {% if page.title != nil %}
+    {% if page.excluded or page.title != nil %}
         "title"    : "{{ page.title | strip_newlines | escape }}",
         "category" : "{{ page.category }}",
         "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",

--- a/_includes/default/search_input.liquid
+++ b/_includes/default/search_input.liquid
@@ -13,7 +13,7 @@
 {% if site.pages.size > 0 %},{% endif %}
 {% for page in site.pages %}
     {
-    {% unless page.title == nil or page.title == "404 Page not found" %}
+    {% unless page.hide or page.title == nil %}
         "title"    : "{{ page.title | strip_newlines | escape }}",
         "category" : "{{ page.category }}",
         "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",

--- a/_includes/default/search_input.liquid
+++ b/_includes/default/search_input.liquid
@@ -1,0 +1,41 @@
+[
+{% for post in site.posts %}
+    {
+    "title"    : "{{ post.title | strip_newlines | escape }}",
+    "category" : "{{ post.category }}",
+    "tags"     : "{{ post.tags | join: ', ' | prepend: " " }}",
+    "url"      : "{{ post.url | relative_url }}",
+    "date"     : "{{ post.date | date: "%B %-d, %Y" }}",
+    "excerpt"  : {{ post.content | strip_html | strip_newlines | strip | escape | truncate: '250' | escape | jsonify }},
+    "content"  : {{ post.content | strip_html | strip_newlines | strip | escape | jsonify }}
+    }{% unless forloop.last %},{% endunless %}
+{% endfor %}
+{% if site.pages.size > 0 %},{% endif %}
+{% for page in site.pages %}
+    {
+    {% unless page.title == nil or page.title == "404 Page not found" %}
+        "title"    : "{{ page.title | strip_newlines | escape }}",
+        "category" : "{{ page.category }}",
+        "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
+        "url"      : "{{ page.url | relative_url }}",
+        "date"     : "{{ page.date | date: "%B %-d, %Y" | default: "N/A" }}",
+        "excerpt"  : {{ page.content | strip_html | strip_newlines | strip | escape | truncate: '250' | escape | jsonify }},
+        "content"  : {{ page.content | strip_html | strip_newlines | strip | escape | jsonify }}
+    {% endunless %}
+    }{% unless forloop.last %},{% endunless %}
+{% endfor %}
+{% if site.portfolio.size > 0 %},{% endif %}
+{% for page in site.portfolio %}
+    {
+    {% if page.title != nil %}
+        "title"    : "{{ page.title | strip_newlines | escape }}",
+        "category" : "{{ page.category }}",
+        "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
+        "url"      : "{{ page.url | relative_url }}",
+        "date"     : "{{ page.date | date: "%B %-d, %Y" | default: "N/A" }}",
+        "excerpt"  : {{ page.content | strip_html | strip_newlines | strip | escape | truncate: '250' | jsonify }},
+        "content"  : {{ page.content | strip_html | strip_newlines | strip | escape | jsonify }}
+    {% endif %}
+    } {% unless forloop.last %},{% endunless %}
+{% endfor %}
+]

--- a/_portfolio/hanoi.md
+++ b/_portfolio/hanoi.md
@@ -5,6 +5,8 @@ img: "assets/img/portfolio/toh.png"
 date: September 2014
 ---
 
+The tower of Hanoi...
+
 ![image]({{ page.img | relative_url }})
 
 Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, 

--- a/assets/data/search.liquid
+++ b/assets/data/search.liquid
@@ -1,29 +1,8 @@
 ---
 ---
-[
-  {% for post in site.posts %}
-  {
-    "title"    : "{{ post.title | strip_newlines | escape }}",
-    "category" : "{{ post.category }}",
-    "tags"     : "{{ post.tags | join: ', ' | prepend: " " }}",
-    "url"      : "{{ post.url | relative_url }}",
-    "date"     : "{{ post.date | date: "%B %-d, %Y" }}",
-    "excerpt"  : {{ post.content | strip_html | truncate: '250' | escape | jsonify }},
-  "content"  : {{ post.content | strip_html | escape | jsonify }}
-} {% unless forloop.last %},{% endunless %}
-  {% endfor %}
-  {% if site.portfolio.size > 0 %},{% endif %}
-  {% for page in site.portfolio %}
-  {
-  {% if page.title != nil %}
-  "title"    : "{{ page.title | strip_newlines | escape }}",
-  "category" : "{{ page.category }}",
-  "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
-  "url"      : "{{ page.url | relative_url }}",
-  "date"     : "{{ page.date | date: "%B %-d, %Y" }}",
-  "excerpt"  : {{ page.content | strip_html | truncate: '250' | jsonify }},
-  "content"  : {{ page.content | strip_html | escape | jsonify }}
-  {% endif %}
-} {% unless forloop.last %},{% endunless %}
-  {% endfor %}
-]
+{% comment %}
+The json is created in search_input.liquid and included here to be compresed
+{% endcomment %}
+{% capture _search %}{% include default/search_input.liquid %}{% endcapture %}
+{% assign emptyField = '{ },' %}
+{{ _search | split: " " | join: " " | remove: emptyField }}

--- a/pages/404.md
+++ b/pages/404.md
@@ -3,6 +3,7 @@ layout: page
 title: "404 Page not found"
 permalink: /404.html
 hide: true
+excluded: true
 ---
 
 Sorry, the requested page wasn't found on the server.

--- a/pages/categories.md
+++ b/pages/categories.md
@@ -3,4 +3,5 @@ layout: categories
 title: Categories
 permalink: /categories/
 hide: true
+excluded: true
 ---

--- a/pages/gallery.md
+++ b/pages/gallery.md
@@ -4,12 +4,13 @@ title: Gallery
 subtitle: From the pexels folder
 permalink: /gallery/
 gallery_path: "assets/img/pexels"
+excluded: true
 position: 3
 tags: [Page]
 ---
 
 This is a photo gallery made from the static files in the `assets/img/pexels` folder. 
-I wanted to create automatically a simple gallery from a folder without having to create a markdown page as you would for the portfolio.
+I wanted to automatically create a simple gallery from a folder without having to create a markdown page as you would for the portfolio.
 
 
 {% include gallery.html gallery_path=page.gallery_path %}

--- a/pages/search.md
+++ b/pages/search.md
@@ -5,5 +5,6 @@ permalink: /search/
 subtitle: "What are you looking for?"
 feature-img: "assets/img/pexels/search-map.jpeg"
 icon: "fa-search"
+excluded: true
 position: 5
 ---


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
The liquid markup creates a lot of space which are not necessary for the generated json. Compressing it with fewer spaces and empty lines should make it faster.

- Added search through pages
- Extended search to any collections (not just portfolio)
- Add `excluded` key work to exclude page from the search