### PR TITLE
Fix no collection search

### DIFF
--- a/_includes/default/search_input.liquid
+++ b/_includes/default/search_input.liquid
@@ -28,8 +28,8 @@
 {% endfor %}
 {% if site.collections.size > 1 %},{% endif %}
 {% for collection in site.collections %}
-    {% for page in site[collection.label] %}
-        {% unless collection.label == 'posts' %}
+    {% unless collection.label == 'posts' or site[collection.label].size == 0 %}
+        {% for page in site[collection.label] %}
             {
             {% if page.excluded or page.title != nil %}
                 "title"    : "{{ page.title | strip_newlines | escape }}",
@@ -41,8 +41,10 @@
                 "content"  : {{ page.content | strip_html | strip_newlines | strip | escape | jsonify }}
             {% endif %}
             }{% unless forloop.last %},{% endunless %}
-        {% endunless %}
-    {% endfor %}
+        {% endfor %}
+    {% else %}
+        {}
+    {% endunless %}
     {% unless forloop.last %},{% endunless %}
 {% endfor %}
 ]

--- a/_includes/default/search_input.liquid
+++ b/_includes/default/search_input.liquid
@@ -26,20 +26,22 @@
     {% endunless %}
     }{% unless forloop.last %},{% endunless %}
 {% endfor %}
-{% if site.collections.size > 0 %},{% endif %}
+{% if site.collections.size > 1 %},{% endif %}
 {% for collection in site.collections %}
     {% for page in site[collection.label] %}
-        {
-        {% if page.excluded or page.title != nil %}
-            "title"    : "{{ page.title | strip_newlines | escape }}",
-            "category" : "{{ page.category }}",
-            "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
-            "url"      : "{{ page.url | relative_url }}",
-            "date"     : "{{ page.date | date: "%B %-d, %Y" | default: "N/A" }}",
-            "excerpt"  : {{ page.content | strip_html | strip_newlines | strip | escape | truncate: '250' | jsonify }},
-            "content"  : {{ page.content | strip_html | strip_newlines | strip | escape | jsonify }}
-        {% endif %}
-        }{% unless forloop.last %},{% endunless %}
+        {% unless collection.label == 'posts' %}
+            {
+            {% if page.excluded or page.title != nil %}
+                "title"    : "{{ page.title | strip_newlines | escape }}",
+                "category" : "{{ page.category }}",
+                "tags"     : "{{ page.tags | join: ', ' | prepend: " " }}",
+                "url"      : "{{ page.url | relative_url }}",
+                "date"     : "{{ page.date | date: "%B %-d, %Y" | default: "N/A" }}",
+                "excerpt"  : {{ page.content | strip_html | strip_newlines | strip | escape | truncate: '250' | jsonify }},
+                "content"  : {{ page.content | strip_html | strip_newlines | strip | escape | jsonify }}
+            {% endif %}
+            }{% unless forloop.last %},{% endunless %}
+        {% endunless %}
     {% endfor %}
     {% unless forloop.last %},{% endunless %}
 {% endfor %}


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
<!-- A brief explanation of what the PR is about -->
- When not using the portfolio collection, the search breaks.
- Duplicates the post entry if posts are not escaped.

