### PR TITLE
Drop support for ruby < 2.7.4

### DIFF
--- a/.github/workflows/gem-build.yml
+++ b/.github/workflows/gem-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ '3.0', '3.1', '3.2' ]
+        ruby-version: [ '2.7.4', '3.0', '3.1', '3.2' ]
 
     steps:
       - uses: actions/checkout@v3
@@ -33,6 +33,7 @@ jobs:
       - name: Gems
         continue-on-error: true
         run: |
+          gem install github-pages
           gem update --system
       - name: Install theme gems
         continue-on-error: true

--- a/.github/workflows/gem-build.yml
+++ b/.github/workflows/gem-build.yml
@@ -34,12 +34,15 @@ jobs:
         continue-on-error: true
         run: |
           gem update --system
+      - name: Install theme gems
+        continue-on-error: true
+        run: |
           gem install type-on-strap
           gem install jekyll-theme-type-on-strap
       - name: GPR
         continue-on-error: true
         run: |
-          gem install type-on-strap --version "2.4.7" --source "https://rubygems.pkg.github.com/sylhare"
+          gem install type-on-strap --version "2.4.8" --source "https://rubygems.pkg.github.com/sylhare"
       - name: Build with Docker
         continue-on-error: true
         run: |

--- a/.github/workflows/gem-build.yml
+++ b/.github/workflows/gem-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -4,7 +4,7 @@ LABEL image="sylhare/type-on-strap"
 
 # Create Type-on-strap Gemfile
 RUN echo "source \"https://rubygems.org\"" >> Gemfile
-RUN echo "gem 'type-on-strap', '>= 2.4.7', '< 3.0'" >> Gemfile
+RUN echo "gem 'type-on-strap', '>= 2.4.8', '< 3.0'" >> Gemfile
 RUN echo "Adding the Gemfile" >> cat Gemfile
 
 # Install the theme

--- a/type-on-strap.gemspec
+++ b/type-on-strap.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                                Thanks for using Type on strap v2+!
                                MSG
 
-  spec.required_ruby_version   = '>= 2.7.0'
+  spec.required_ruby_version   = '>= 3.x'
 
   spec.add_runtime_dependency "jekyll", ">= 3.8", "< 5.0"
   spec.add_runtime_dependency "jekyll-feed", ">= 0.15.1", "<= 0.17"

--- a/type-on-strap.gemspec
+++ b/type-on-strap.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                                Thanks for using Type on strap v2+!
                                MSG
 
-  spec.required_ruby_version   = '>= 3.x'
+  spec.required_ruby_version   = ">= 2.7.4", "< 4.0"
 
   spec.add_runtime_dependency "jekyll", ">= 3.8", "< 5.0"
   spec.add_runtime_dependency "jekyll-feed", ">= 0.15.1", "<= 0.17"


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
Ruby 2.7 has been end of life since march this year, dropping support for it on newer version of the theme.
-> https://endoflife.date/ruby