### PR TITLE
Add item counts to categories

### DIFF
--- a/_layouts/categories.liquid
+++ b/_layouts/categories.liquid
@@ -9,7 +9,7 @@ layout: page
             {% for category in site.categories %}
                 <a href="#{{ category | first | cgi_escape }}" class="category-anchor">
                     <li>
-                        {{ category | first }}
+                        {{ category | first }} 
                         <!-- {{ category | last | size | times: 100 | divided_by: site.tags.size | plus: 50 | divided_by: 100.0 }} -->
                         <!-- <span class="category-number">{{ category | last | size }}</span> -->
                     </li>
@@ -20,7 +20,12 @@ layout: page
             {% for category in site.categories %}
                 <div class="category-group">
                     {% capture group %}{{ category | first }}{% endcapture %}
-                    <h4 id="{{ group }}" class="title">{{ group }}</h4>
+                    <h4 id="{{ group }}" class="title">
+                        {{ group }}
+                        {% if page.showCounts %}
+                            ({{site.categories[group].size}})
+                        {% endif %}
+                    </h4>
                     <div class="items">
                         {% for post in site.categories[group] %}
                             <a href="{{ post.url | relative_url }}" class="category-post-link">

--- a/pages/categories.md
+++ b/pages/categories.md
@@ -4,4 +4,5 @@ title: Categories
 permalink: /categories/
 hide: true
 excluded: true
+showCounts: false
 ---


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
A count of pages that have a specific category can be shown in the categories page.

### Screenshot
![Screenshot_20240613_211819](https://github.com/sylhare/Type-on-Strap/assets/10497049/aa08103b-4ac6-4cd3-b482-8f9b5c87b97e)
