### PR TITLE
Add gem suggestion for more robust build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,9 @@
 source "https://rubygems.org"
 gemspec
+
+# Should be included in Jekyll but depending on the version Jekyll and Ruby version, it may not be included
+# gem 'webrick'
+# gem 'kramdown-parser-gfm'
+
+# For github pages compatibility
+# gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
Depending on the jekyll and ruby version installed it might show an error if those are not in the gemfile. They should be included in jekyll already.
Since adding them depends on the system I'll have them in comments instead.

Error for kramdown
```
  Dependency Error: Yikes! It looks like you don't have kramdown-parser-gfm or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- kramdown-parser-gfm' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/! 
```
> Add `gem 'kramdown-parser-gfm'`

Error for webrick:
```
/opt/homebrew/lib/ruby/gems/3.3.0/gems/jekyll-3.9.5/lib/jekyll/commands/serve/servlet.rb:3: warning: webrick was loaded from the standard library, but is not part of the default gems since Ruby 3.0.0. Add webrick to your Gemfile or gemspec. Also contact author of jekyll-3.9.5 to add webrick into its gemspec.
bundler: failed to load command: jekyll (/opt/homebrew/lib/ruby/gems/3.3.0/bin/jekyll)
/opt/homebrew/Cellar/ruby/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- webrick (LoadError)
```

> Add `gem 'webrick'`
