### PR TITLE
Fix deprecation warning for fontawesome

### DIFF
--- a/_sass/external/_font-awesome.scss
+++ b/_sass/external/_font-awesome.scss
@@ -2,11 +2,14 @@
  * Type-on-strap Font Awesome kit v6.7.1
  * Find the version and license of the included Font Awesome here: _sass/external/font-awesome/fontawesome.scss
  */
-$fa-inverse: var(--background);
 $fa-font-path: "../fonts/font-awesome" !default;
+$fa-inverse: var(--background);
 
-@import 'font-awesome/fontawesome';
-@import 'font-awesome/brands';
-@import 'font-awesome/regular';
-@import 'font-awesome/solid';
-@import 'font-awesome/v4-shims';
+@use 'font-awesome/fontawesome' with (
+  $fa-font-path: $fa-font-path,
+  $fa-inverse: $fa-inverse
+);
+@use 'font-awesome/brands';
+@use 'font-awesome/regular';
+@use 'font-awesome/solid';
+@use 'font-awesome/v4-shims';

--- a/_sass/external/font-awesome/_animated.scss
+++ b/_sass/external/font-awesome/_animated.scss
@@ -1,95 +1,97 @@
+@use "variables";
+
 // animating icons
 // --------------------------
 
-.#{$fa-css-prefix}-beat {
-  animation-name: #{$fa-css-prefix}-beat;
-  animation-delay: var(--#{$fa-css-prefix}-animation-delay, 0s);
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 1s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, ease-in-out);
+.#{variables.$fa-css-prefix}-beat {
+  animation-name: #{variables.$fa-css-prefix}-beat;
+  animation-delay: var(--#{variables.$fa-css-prefix}-animation-delay, 0s);
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 1s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, ease-in-out);
 }
 
-.#{$fa-css-prefix}-bounce {
-  animation-name: #{$fa-css-prefix}-bounce;
-  animation-delay: var(--#{$fa-css-prefix}-animation-delay, 0s);
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 1s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, cubic-bezier(0.280, 0.840, 0.420, 1));
+.#{variables.$fa-css-prefix}-bounce {
+  animation-name: #{variables.$fa-css-prefix}-bounce;
+  animation-delay: var(--#{variables.$fa-css-prefix}-animation-delay, 0s);
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 1s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, cubic-bezier(0.280, 0.840, 0.420, 1));
 }
 
-.#{$fa-css-prefix}-fade {
-  animation-name: #{$fa-css-prefix}-fade;
-  animation-delay: var(--#{$fa-css-prefix}-animation-delay, 0s);
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 1s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, cubic-bezier(.4,0,.6,1));
+.#{variables.$fa-css-prefix}-fade {
+  animation-name: #{variables.$fa-css-prefix}-fade;
+  animation-delay: var(--#{variables.$fa-css-prefix}-animation-delay, 0s);
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 1s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, cubic-bezier(.4,0,.6,1));
 }
 
-.#{$fa-css-prefix}-beat-fade {
-  animation-name: #{$fa-css-prefix}-beat-fade;
-  animation-delay: var(--#{$fa-css-prefix}-animation-delay, 0s);
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 1s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, cubic-bezier(.4,0,.6,1));
+.#{variables.$fa-css-prefix}-beat-fade {
+  animation-name: #{variables.$fa-css-prefix}-beat-fade;
+  animation-delay: var(--#{variables.$fa-css-prefix}-animation-delay, 0s);
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 1s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, cubic-bezier(.4,0,.6,1));
 }
 
-.#{$fa-css-prefix}-flip {
-  animation-name: #{$fa-css-prefix}-flip;
-  animation-delay: var(--#{$fa-css-prefix}-animation-delay, 0s);
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 1s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, ease-in-out);
+.#{variables.$fa-css-prefix}-flip {
+  animation-name: #{variables.$fa-css-prefix}-flip;
+  animation-delay: var(--#{variables.$fa-css-prefix}-animation-delay, 0s);
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 1s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, ease-in-out);
 }
 
-.#{$fa-css-prefix}-shake {
-  animation-name: #{$fa-css-prefix}-shake;
-  animation-delay: var(--#{$fa-css-prefix}-animation-delay, 0s);
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 1s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, linear);
+.#{variables.$fa-css-prefix}-shake {
+  animation-name: #{variables.$fa-css-prefix}-shake;
+  animation-delay: var(--#{variables.$fa-css-prefix}-animation-delay, 0s);
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 1s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, linear);
 }
 
-.#{$fa-css-prefix}-spin {
-  animation-name: #{$fa-css-prefix}-spin;
-  animation-delay: var(--#{$fa-css-prefix}-animation-delay, 0s);
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 2s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, linear);
+.#{variables.$fa-css-prefix}-spin {
+  animation-name: #{variables.$fa-css-prefix}-spin;
+  animation-delay: var(--#{variables.$fa-css-prefix}-animation-delay, 0s);
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 2s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, linear);
 }
 
-.#{$fa-css-prefix}-spin-reverse {
-  --#{$fa-css-prefix}-animation-direction: reverse;
+.#{variables.$fa-css-prefix}-spin-reverse {
+  --#{variables.$fa-css-prefix}-animation-direction: reverse;
 }
 
-.#{$fa-css-prefix}-pulse,
-.#{$fa-css-prefix}-spin-pulse {
-  animation-name: #{$fa-css-prefix}-spin;
-  animation-direction: var(--#{$fa-css-prefix}-animation-direction, normal);
-  animation-duration: var(--#{$fa-css-prefix}-animation-duration, 1s);
-  animation-iteration-count: var(--#{$fa-css-prefix}-animation-iteration-count, infinite);
-  animation-timing-function: var(--#{$fa-css-prefix}-animation-timing, steps(8));
+.#{variables.$fa-css-prefix}-pulse,
+.#{variables.$fa-css-prefix}-spin-pulse {
+  animation-name: #{variables.$fa-css-prefix}-spin;
+  animation-direction: var(--#{variables.$fa-css-prefix}-animation-direction, normal);
+  animation-duration: var(--#{variables.$fa-css-prefix}-animation-duration, 1s);
+  animation-iteration-count: var(--#{variables.$fa-css-prefix}-animation-iteration-count, infinite);
+  animation-timing-function: var(--#{variables.$fa-css-prefix}-animation-timing, steps(8));
 }
 
 // if agent or operating system prefers reduced motion, disable animations
 // see: https://www.smashingmagazine.com/2020/09/design-reduced-motion-sensitivities/
 // see: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
 @media (prefers-reduced-motion: reduce) {
-  .#{$fa-css-prefix}-beat,
-  .#{$fa-css-prefix}-bounce,
-  .#{$fa-css-prefix}-fade,
-  .#{$fa-css-prefix}-beat-fade,
-  .#{$fa-css-prefix}-flip,
-  .#{$fa-css-prefix}-pulse,
-  .#{$fa-css-prefix}-shake,
-  .#{$fa-css-prefix}-spin,
-  .#{$fa-css-prefix}-spin-pulse {
+  .#{variables.$fa-css-prefix}-beat,
+  .#{variables.$fa-css-prefix}-bounce,
+  .#{variables.$fa-css-prefix}-fade,
+  .#{variables.$fa-css-prefix}-beat-fade,
+  .#{variables.$fa-css-prefix}-flip,
+  .#{variables.$fa-css-prefix}-pulse,
+  .#{variables.$fa-css-prefix}-shake,
+  .#{variables.$fa-css-prefix}-spin,
+  .#{variables.$fa-css-prefix}-spin-pulse {
     animation-delay: -1ms;
     animation-duration: 1ms;
     animation-iteration-count: 1;
@@ -98,43 +100,43 @@
   }
 }
 
-@keyframes #{$fa-css-prefix}-beat {
+@keyframes #{variables.$fa-css-prefix}-beat {
   0%, 90% { transform: scale(1); }
-  45% { transform: scale(var(--#{$fa-css-prefix}-beat-scale, 1.25)); }
+  45% { transform: scale(var(--#{variables.$fa-css-prefix}-beat-scale, 1.25)); }
 }
 
-@keyframes #{$fa-css-prefix}-bounce {
+@keyframes #{variables.$fa-css-prefix}-bounce {
   0%   { transform: scale(1,1) translateY(0); }
-  10%  { transform: scale(var(--#{$fa-css-prefix}-bounce-start-scale-x, 1.1),var(--#{$fa-css-prefix}-bounce-start-scale-y, 0.9)) translateY(0); }
-  30%  { transform: scale(var(--#{$fa-css-prefix}-bounce-jump-scale-x, 0.9),var(--#{$fa-css-prefix}-bounce-jump-scale-y, 1.1)) translateY(var(--#{$fa-css-prefix}-bounce-height, -0.5em)); }
-  50%  { transform: scale(var(--#{$fa-css-prefix}-bounce-land-scale-x, 1.05),var(--#{$fa-css-prefix}-bounce-land-scale-y, 0.95)) translateY(0); }
-  57%  { transform: scale(1,1) translateY(var(--#{$fa-css-prefix}-bounce-rebound, -0.125em)); }
+  10%  { transform: scale(var(--#{variables.$fa-css-prefix}-bounce-start-scale-x, 1.1),var(--#{variables.$fa-css-prefix}-bounce-start-scale-y, 0.9)) translateY(0); }
+  30%  { transform: scale(var(--#{variables.$fa-css-prefix}-bounce-jump-scale-x, 0.9),var(--#{variables.$fa-css-prefix}-bounce-jump-scale-y, 1.1)) translateY(var(--#{variables.$fa-css-prefix}-bounce-height, -0.5em)); }
+  50%  { transform: scale(var(--#{variables.$fa-css-prefix}-bounce-land-scale-x, 1.05),var(--#{variables.$fa-css-prefix}-bounce-land-scale-y, 0.95)) translateY(0); }
+  57%  { transform: scale(1,1) translateY(var(--#{variables.$fa-css-prefix}-bounce-rebound, -0.125em)); }
   64%  { transform: scale(1,1) translateY(0); }
   100% { transform: scale(1,1) translateY(0); }
 }
 
-@keyframes #{$fa-css-prefix}-fade {
-  50% { opacity: var(--#{$fa-css-prefix}-fade-opacity, 0.4); }
+@keyframes #{variables.$fa-css-prefix}-fade {
+  50% { opacity: var(--#{variables.$fa-css-prefix}-fade-opacity, 0.4); }
 }
 
-@keyframes #{$fa-css-prefix}-beat-fade {
+@keyframes #{variables.$fa-css-prefix}-beat-fade {
   0%, 100% {
-    opacity: var(--#{$fa-css-prefix}-beat-fade-opacity, 0.4);
+    opacity: var(--#{variables.$fa-css-prefix}-beat-fade-opacity, 0.4);
     transform: scale(1);
   }
   50% {
     opacity: 1;
-    transform: scale(var(--#{$fa-css-prefix}-beat-fade-scale, 1.125));
+    transform: scale(var(--#{variables.$fa-css-prefix}-beat-fade-scale, 1.125));
   }
 }
 
-@keyframes #{$fa-css-prefix}-flip {
+@keyframes #{variables.$fa-css-prefix}-flip {
   50% {
-    transform: rotate3d(var(--#{$fa-css-prefix}-flip-x, 0), var(--#{$fa-css-prefix}-flip-y, 1), var(--#{$fa-css-prefix}-flip-z, 0), var(--#{$fa-css-prefix}-flip-angle, -180deg));
+    transform: rotate3d(var(--#{variables.$fa-css-prefix}-flip-x, 0), var(--#{variables.$fa-css-prefix}-flip-y, 1), var(--#{variables.$fa-css-prefix}-flip-z, 0), var(--#{variables.$fa-css-prefix}-flip-angle, -180deg));
   }
 }
 
-@keyframes #{$fa-css-prefix}-shake {
+@keyframes #{variables.$fa-css-prefix}-shake {
   0% { transform: rotate(-15deg); }
   4% { transform: rotate(15deg); }
   8%, 24% { transform: rotate(-18deg); }
@@ -146,7 +148,7 @@
   40%, 100% { transform: rotate(0deg); }
 }
 
-@keyframes #{$fa-css-prefix}-spin {
+@keyframes #{variables.$fa-css-prefix}-spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }

--- a/_sass/external/font-awesome/_bordered-pulled.scss
+++ b/_sass/external/font-awesome/_bordered-pulled.scss
@@ -1,20 +1,22 @@
+@use "variables";
+
 // bordered + pulled icons
 // -------------------------
 
-.#{$fa-css-prefix}-border {
-  border-color: var(--#{$fa-css-prefix}-border-color, #{$fa-border-color});
-  border-radius: var(--#{$fa-css-prefix}-border-radius, #{$fa-border-radius});
-  border-style: var(--#{$fa-css-prefix}-border-style, #{$fa-border-style});
-  border-width: var(--#{$fa-css-prefix}-border-width, #{$fa-border-width});
-  padding: var(--#{$fa-css-prefix}-border-padding, #{$fa-border-padding});
+.#{variables.$fa-css-prefix}-border {
+  border-color: var(--#{variables.$fa-css-prefix}-border-color, #{variables.$fa-border-color});
+  border-radius: var(--#{variables.$fa-css-prefix}-border-radius, #{variables.$fa-border-radius});
+  border-style: var(--#{variables.$fa-css-prefix}-border-style, #{variables.$fa-border-style});
+  border-width: var(--#{variables.$fa-css-prefix}-border-width, #{variables.$fa-border-width});
+  padding: var(--#{variables.$fa-css-prefix}-border-padding, #{variables.$fa-border-padding});
 }
 
-.#{$fa-css-prefix}-pull-left {
+.#{variables.$fa-css-prefix}-pull-left {
   float: left;
-  margin-right: var(--#{$fa-css-prefix}-pull-margin, #{$fa-pull-margin}); 
+  margin-right: var(--#{variables.$fa-css-prefix}-pull-margin, #{variables.$fa-pull-margin}); 
 }
 
-.#{$fa-css-prefix}-pull-right {
+.#{variables.$fa-css-prefix}-pull-right {
   float: right;
-  margin-left: var(--#{$fa-css-prefix}-pull-margin, #{$fa-pull-margin}); 
+  margin-left: var(--#{variables.$fa-css-prefix}-pull-margin, #{variables.$fa-pull-margin}); 
 }

--- a/_sass/external/font-awesome/_core.scss
+++ b/_sass/external/font-awesome/_core.scss
@@ -1,21 +1,24 @@
+@use "mixins";
+@use "variables";
+
 // base icon class definition
 // -------------------------
 
-.#{$fa-css-prefix} {
-  font-family: var(--#{$fa-css-prefix}-style-family, '#{$fa-style-family}');
-  font-weight: var(--#{$fa-css-prefix}-style, #{$fa-style});
+.#{variables.$fa-css-prefix} {
+  font-family: var(--#{variables.$fa-css-prefix}-style-family, '#{variables.$fa-style-family}');
+  font-weight: var(--#{variables.$fa-css-prefix}-style, #{variables.$fa-style});
 }
 
 .fas,
 .far,
 .fab,
-.#{$fa-css-prefix}-solid,
-.#{$fa-css-prefix}-regular,
-.#{$fa-css-prefix}-brands,
-.#{$fa-css-prefix} {
+.#{variables.$fa-css-prefix}-solid,
+.#{variables.$fa-css-prefix}-regular,
+.#{variables.$fa-css-prefix}-brands,
+.#{variables.$fa-css-prefix} {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  display: var(--#{$fa-css-prefix}-display, #{$fa-display});
+  display: var(--#{variables.$fa-css-prefix}-display, #{variables.$fa-display});
   font-style: normal;
   font-variant: normal;
   line-height: 1;
@@ -25,25 +28,25 @@
 .fas::before,
 .far::before,
 .fab::before,
-.#{$fa-css-prefix}-solid::before,
-.#{$fa-css-prefix}-regular::before,
-.#{$fa-css-prefix}-brands::before,
+.#{variables.$fa-css-prefix}-solid::before,
+.#{variables.$fa-css-prefix}-regular::before,
+.#{variables.$fa-css-prefix}-brands::before,
 .fa::before {
-  content: var(#{$fa-icon-property});
+  content: var(#{variables.$fa-icon-property});
 }
 
-.#{$fa-css-prefix}-classic,
+.#{variables.$fa-css-prefix}-classic,
 .fas,
-.#{$fa-css-prefix}-solid,
+.#{variables.$fa-css-prefix}-solid,
 .far,
-.#{$fa-css-prefix}-regular {
+.#{variables.$fa-css-prefix}-regular {
   font-family: 'Font Awesome 6 Free';
 }
-.#{$fa-css-prefix}-brands,
+.#{variables.$fa-css-prefix}-brands,
 .fab {
   font-family: 'Font Awesome 6 Brands';
 }
 
 %fa-icon {
-  @include fa-icon;
+  @include mixins.fa-icon;
 }

--- a/_sass/external/font-awesome/_fixed-width.scss
+++ b/_sass/external/font-awesome/_fixed-width.scss
@@ -1,7 +1,9 @@
+@use "variables";
+
 // fixed-width icons
 // -------------------------
 
-.#{$fa-css-prefix}-fw {
+.#{variables.$fa-css-prefix}-fw {
   text-align: center;
-  width: $fa-fw-width;
+  width: variables.$fa-fw-width;
 }

--- a/_sass/external/font-awesome/_functions.scss
+++ b/_sass/external/font-awesome/_functions.scss
@@ -1,9 +1,11 @@
+@use "sass:math";
+@use "sass:string";
 // functions
 // --------------------------
 
 // fa-content: convenience function used to set content property
 @function fa-content($fa-var) {
-  @return unquote("\"#{ $fa-var }\"");
+  @return string.unquote("\"#{ $fa-var }\"");
 }
 
 // fa-divide: Originally obtained from the Bootstrap https://github.com/twbs/bootstrap
@@ -33,8 +35,8 @@
 
 @function fa-divide($dividend, $divisor, $precision: 10) {
   $sign: if($dividend > 0 and $divisor > 0, 1, -1);
-  $dividend: abs($dividend);
-  $divisor: abs($divisor);
+  $dividend: math.abs($dividend);
+  $divisor: math.abs($divisor);
   $quotient: 0;
   $remainder: $dividend;
   @if $dividend == 0 {

--- a/_sass/external/font-awesome/_icons.scss
+++ b/_sass/external/font-awesome/_icons.scss
@@ -1,13 +1,16 @@
+@use "sass:string";
+@use "variables";
+
 // specific icon class definition
 // -------------------------
 
 /* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
 readers do not read off random characters that represent icons */
 
-@each $name, $icon in $fa-icons {
-  .#{$fa-css-prefix}-#{$name} {
-    #{$fa-icon-property}: unquote("\"#{ $icon }\"");
-    #{$fa-duotone-icon-property}: unquote("\"#{$icon}#{$icon}\"");
+@each $name, $icon in variables.$fa-icons {
+  .#{variables.$fa-css-prefix}-#{$name} {
+    #{variables.$fa-icon-property}: string.unquote("\"#{ $icon }\"");
+    #{variables.$fa-duotone-icon-property}: string.unquote("\"#{$icon}#{$icon}\"");
   }
 }
 

--- a/_sass/external/font-awesome/_list.scss
+++ b/_sass/external/font-awesome/_list.scss
@@ -1,18 +1,20 @@
+@use "variables";
+
 // icons in a list
 // -------------------------
 
-.#{$fa-css-prefix}-ul {
+.#{variables.$fa-css-prefix}-ul {
   list-style-type: none;
-  margin-left: var(--#{$fa-css-prefix}-li-margin, #{$fa-li-margin});
+  margin-left: var(--#{variables.$fa-css-prefix}-li-margin, #{variables.$fa-li-margin});
   padding-left: 0;
 
   > li { position: relative; }
 }
 
-.#{$fa-css-prefix}-li {
-  left: calc(-1 * var(--#{$fa-css-prefix}-li-width, #{$fa-li-width}));
+.#{variables.$fa-css-prefix}-li {
+  left: calc(-1 * var(--#{variables.$fa-css-prefix}-li-width, #{variables.$fa-li-width}));
   position: absolute;
   text-align: center;
-  width: var(--#{$fa-css-prefix}-li-width, #{$fa-li-width});
+  width: var(--#{variables.$fa-css-prefix}-li-width, #{variables.$fa-li-width});
   line-height: inherit;
 }

--- a/_sass/external/font-awesome/_mixins.scss
+++ b/_sass/external/font-awesome/_mixins.scss
@@ -1,3 +1,7 @@
+@use "sass:string";
+@use "functions";
+@use "variables";
+
 // mixins
 // --------------------------
 
@@ -14,9 +18,9 @@
 
 // sets relative font-sizing and alignment (in _sizing)
 @mixin fa-size ($font-size) {
-  font-size: fa-divide($font-size, $fa-size-scale-base) * 1em; // converts step in sizing scale into an em-based value that's relative to the scale's base
-  line-height: fa-divide(1, $font-size) * 1em; // sets the line-height of the icon back to that of it's parent
-  vertical-align: (fa-divide(6, $font-size) - fa-divide(3, 8)) * 1em; // vertically centers the icon taking into account the surrounding text's descender
+  font-size: functions.fa-divide($font-size, variables.$fa-size-scale-base) * 1em; // converts step in sizing scale into an em-based value that's relative to the scale's base
+  line-height: functions.fa-divide(1, $font-size) * 1em; // sets the line-height of the icon back to that of it's parent
+  vertical-align: (functions.fa-divide(6, $font-size) - functions.fa-divide(3, 8)) * 1em; // vertically centers the icon taking into account the surrounding text's descender
 }
 
 // only display content to screen readers
@@ -51,15 +55,15 @@
 @mixin fa-icon-solid($fa-var) {
   @extend .fa-solid;
 
-  & { #{$fa-icon-property}: unquote("\"#{ $fa-var }\""); #{$fa-duotone-icon-property}: unquote("\"#{ $fa-var }#{ $fa-var }\""); }
+  & { #{variables.$fa-icon-property}: string.unquote("\"#{ $fa-var }\""); #{variables.$fa-duotone-icon-property}: string.unquote("\"#{ $fa-var }#{ $fa-var }\""); }
 }
 @mixin fa-icon-regular($fa-var) {
   @extend .fa-regular;
 
-  & { #{$fa-icon-property}: unquote("\"#{ $fa-var }\""); #{$fa-duotone-icon-property}: unquote("\"#{ $fa-var }#{ $fa-var }\""); }
+  & { #{variables.$fa-icon-property}: string.unquote("\"#{ $fa-var }\""); #{variables.$fa-duotone-icon-property}: string.unquote("\"#{ $fa-var }#{ $fa-var }\""); }
 }
 @mixin fa-icon-brands($fa-var) {
   @extend .fa-brands;
 
-  & { #{$fa-icon-property}: unquote("\"#{ $fa-var }\""); #{$fa-duotone-icon-property}: unquote("\"#{ $fa-var }#{ $fa-var }\""); }
+  & { #{variables.$fa-icon-property}: string.unquote("\"#{ $fa-var }\""); #{variables.$fa-duotone-icon-property}: string.unquote("\"#{ $fa-var }#{ $fa-var }\""); }
 }

--- a/_sass/external/font-awesome/_rotated-flipped.scss
+++ b/_sass/external/font-awesome/_rotated-flipped.scss
@@ -1,31 +1,33 @@
+@use "variables";
+
 // rotating + flipping icons
 // -------------------------
 
-.#{$fa-css-prefix}-rotate-90 {
+.#{variables.$fa-css-prefix}-rotate-90 {
   transform: rotate(90deg);
 }
 
-.#{$fa-css-prefix}-rotate-180 {
+.#{variables.$fa-css-prefix}-rotate-180 {
   transform: rotate(180deg);
 }
 
-.#{$fa-css-prefix}-rotate-270 {
+.#{variables.$fa-css-prefix}-rotate-270 {
   transform: rotate(270deg);
 }
 
-.#{$fa-css-prefix}-flip-horizontal {
+.#{variables.$fa-css-prefix}-flip-horizontal {
   transform: scale(-1, 1);
 }
 
-.#{$fa-css-prefix}-flip-vertical {
+.#{variables.$fa-css-prefix}-flip-vertical {
   transform: scale(1, -1);
 }
 
-.#{$fa-css-prefix}-flip-both,
-.#{$fa-css-prefix}-flip-horizontal.#{$fa-css-prefix}-flip-vertical {
+.#{variables.$fa-css-prefix}-flip-both,
+.#{variables.$fa-css-prefix}-flip-horizontal.#{variables.$fa-css-prefix}-flip-vertical {
   transform: scale(-1, -1);
 }
 
-.#{$fa-css-prefix}-rotate-by {
-  transform: rotate(var(--#{$fa-css-prefix}-rotate-angle, 0));
+.#{variables.$fa-css-prefix}-rotate-by {
+  transform: rotate(var(--#{variables.$fa-css-prefix}-rotate-angle, 0));
 }

--- a/_sass/external/font-awesome/_screen-reader.scss
+++ b/_sass/external/font-awesome/_screen-reader.scss
@@ -1,14 +1,17 @@
+@use "mixins";
+@use "variables";
+
 // screen-reader utilities
 // -------------------------
 
 // only display content to screen readers
 .sr-only,
-.#{$fa-css-prefix}-sr-only {
-  @include fa-sr-only;
+.#{variables.$fa-css-prefix}-sr-only {
+  @include mixins.fa-sr-only;
 }
 
 // use in conjunction with .sr-only to only display content when it's focused
 .sr-only-focusable,
-.#{$fa-css-prefix}-sr-only-focusable {
-  @include fa-sr-only-focusable;
+.#{variables.$fa-css-prefix}-sr-only-focusable {
+  @include mixins.fa-sr-only-focusable;
 }

--- a/_sass/external/font-awesome/_shims.scss
+++ b/_sass/external/font-awesome/_shims.scss
@@ -1,1578 +1,1581 @@
-.#{$fa-css-prefix}.#{$fa-css-prefix}-glass { #{$fa-icon-property}: unquote("\"#{ $fa-var-martini-glass-empty }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-envelope-o {
+@use "sass:string";
+@use "variables";
+
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-glass { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-martini-glass-empty }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-envelope-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-envelope-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-envelope }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-envelope-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-envelope }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-star }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-remove { #{$fa-icon-property}: unquote("\"#{ $fa-var-xmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-close { #{$fa-icon-property}: unquote("\"#{ $fa-var-xmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gear { #{$fa-icon-property}: unquote("\"#{ $fa-var-gear }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-trash-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-star }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-remove { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-xmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-close { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-xmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gear { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-gear }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-trash-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-trash-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-trash-can }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-home { #{$fa-icon-property}: unquote("\"#{ $fa-var-house }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-trash-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-trash-can }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-home { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-house }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-clock-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-clock-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-clock-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-clock }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-down {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-clock-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-clock }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-down {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-down { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-up {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-down { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-up {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-up { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-play-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-up { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-play-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-play-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-play }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-repeat { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-rotate-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-rotate-right { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-rotate-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-refresh { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrows-rotate }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-list-alt {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-play-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-play }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-repeat { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-rotate-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-rotate-right { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-rotate-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-refresh { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrows-rotate }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-list-alt {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-list-alt { #{$fa-icon-property}: unquote("\"#{ $fa-var-rectangle-list }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dedent { #{$fa-icon-property}: unquote("\"#{ $fa-var-outdent }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-video-camera { #{$fa-icon-property}: unquote("\"#{ $fa-var-video }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-picture-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-list-alt { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-rectangle-list }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dedent { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-outdent }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-video-camera { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-video }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-picture-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-picture-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-image }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-photo {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-picture-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-image }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-photo {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-photo { #{$fa-icon-property}: unquote("\"#{ $fa-var-image }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-image {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-photo { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-image }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-image {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-image { #{$fa-icon-property}: unquote("\"#{ $fa-var-image }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-map-marker { #{$fa-icon-property}: unquote("\"#{ $fa-var-location-dot }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pencil-square-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-image { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-image }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-map-marker { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-location-dot }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pencil-square-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pencil-square-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-pen-to-square }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-edit {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pencil-square-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-pen-to-square }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-edit {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-edit { #{$fa-icon-property}: unquote("\"#{ $fa-var-pen-to-square }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-share-square-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-share-from-square }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-check-square-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-edit { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-pen-to-square }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-share-square-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-share-from-square }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-check-square-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-check-square-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-check }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrows { #{$fa-icon-property}: unquote("\"#{ $fa-var-up-down-left-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-times-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-check-square-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-check }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrows { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-up-down-left-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-times-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-times-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-xmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-check-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-times-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-xmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-check-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-check-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-check }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-mail-forward { #{$fa-icon-property}: unquote("\"#{ $fa-var-share }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-expand { #{$fa-icon-property}: unquote("\"#{ $fa-var-up-right-and-down-left-from-center }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-compress { #{$fa-icon-property}: unquote("\"#{ $fa-var-down-left-and-up-right-to-center }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-eye {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-check-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-check }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-mail-forward { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-share }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-expand { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-up-right-and-down-left-from-center }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-compress { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-down-left-and-up-right-to-center }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-eye {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-eye-slash {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-eye-slash {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-warning { #{$fa-icon-property}: unquote("\"#{ $fa-var-triangle-exclamation }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar { #{$fa-icon-property}: unquote("\"#{ $fa-var-calendar-days }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrows-v { #{$fa-icon-property}: unquote("\"#{ $fa-var-up-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrows-h { #{$fa-icon-property}: unquote("\"#{ $fa-var-left-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bar-chart { #{$fa-icon-property}: unquote("\"#{ $fa-var-chart-column }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bar-chart-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-chart-column }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-twitter-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-warning { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-triangle-exclamation }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-calendar-days }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrows-v { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-up-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrows-h { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-left-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bar-chart { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-chart-column }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bar-chart-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-chart-column }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-twitter-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-twitter-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-twitter }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-twitter-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-twitter }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-facebook }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gears { #{$fa-icon-property}: unquote("\"#{ $fa-var-gears }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thumbs-o-up {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-facebook }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gears { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-gears }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thumbs-o-up {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thumbs-o-up { #{$fa-icon-property}: unquote("\"#{ $fa-var-thumbs-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thumbs-o-down {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thumbs-o-up { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-thumbs-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thumbs-o-down {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thumbs-o-down { #{$fa-icon-property}: unquote("\"#{ $fa-var-thumbs-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-heart-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thumbs-o-down { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-thumbs-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-heart-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-heart-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-heart }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sign-out { #{$fa-icon-property}: unquote("\"#{ $fa-var-right-from-bracket }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-linkedin-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-heart-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-heart }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sign-out { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-right-from-bracket }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-linkedin-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-linkedin-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-linkedin }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thumb-tack { #{$fa-icon-property}: unquote("\"#{ $fa-var-thumbtack }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-external-link { #{$fa-icon-property}: unquote("\"#{ $fa-var-up-right-from-square }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sign-in { #{$fa-icon-property}: unquote("\"#{ $fa-var-right-to-bracket }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-github-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-linkedin-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-linkedin }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thumb-tack { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-thumbtack }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-external-link { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-up-right-from-square }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sign-in { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-right-to-bracket }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-github-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-github-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-github }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-lemon-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-github-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-github }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-lemon-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-lemon-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-lemon }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-square-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-lemon-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-lemon }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-square-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-square-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-square }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bookmark-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-square-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bookmark-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bookmark-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-bookmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-twitter {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bookmark-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bookmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-twitter {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook { #{$fa-icon-property}: unquote("\"#{ $fa-var-facebook-f }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook-f {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-facebook-f }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook-f {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook-f { #{$fa-icon-property}: unquote("\"#{ $fa-var-facebook-f }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-github {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook-f { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-facebook-f }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-github {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-credit-card {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-credit-card {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-feed { #{$fa-icon-property}: unquote("\"#{ $fa-var-rss }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hdd-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-feed { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-rss }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hdd-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hdd-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hard-drive }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-right {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hdd-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hard-drive }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-right {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-right { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-point-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-left {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-right { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-point-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-left {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-left { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-point-left }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-up {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-left { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-point-left }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-up {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-up { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-point-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-down {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-up { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-point-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-down {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-o-down { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-point-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-globe { #{$fa-icon-property}: unquote("\"#{ $fa-var-earth-americas }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-tasks { #{$fa-icon-property}: unquote("\"#{ $fa-var-bars-progress }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrows-alt { #{$fa-icon-property}: unquote("\"#{ $fa-var-maximize }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-group { #{$fa-icon-property}: unquote("\"#{ $fa-var-users }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-chain { #{$fa-icon-property}: unquote("\"#{ $fa-var-link }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cut { #{$fa-icon-property}: unquote("\"#{ $fa-var-scissors }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-files-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-o-down { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-point-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-globe { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-earth-americas }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-tasks { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bars-progress }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrows-alt { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-maximize }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-group { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-users }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-chain { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-link }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cut { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-scissors }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-files-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-files-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-copy }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-floppy-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-files-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-copy }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-floppy-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-floppy-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-floppy-disk }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-save {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-floppy-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-floppy-disk }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-save {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-save { #{$fa-icon-property}: unquote("\"#{ $fa-var-floppy-disk }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-navicon { #{$fa-icon-property}: unquote("\"#{ $fa-var-bars }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-reorder { #{$fa-icon-property}: unquote("\"#{ $fa-var-bars }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-magic { #{$fa-icon-property}: unquote("\"#{ $fa-var-wand-magic-sparkles }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pinterest {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-save { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-floppy-disk }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-navicon { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bars }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-reorder { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bars }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-magic { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-wand-magic-sparkles }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pinterest {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pinterest-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pinterest-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pinterest-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-pinterest }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pinterest-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-pinterest }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-google-plus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-google-plus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus { #{$fa-icon-property}: unquote("\"#{ $fa-var-google-plus-g }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-money { #{$fa-icon-property}: unquote("\"#{ $fa-var-money-bill-1 }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-unsorted { #{$fa-icon-property}: unquote("\"#{ $fa-var-sort }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-desc { #{$fa-icon-property}: unquote("\"#{ $fa-var-sort-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-asc { #{$fa-icon-property}: unquote("\"#{ $fa-var-sort-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-linkedin {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-google-plus-g }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-money { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-money-bill-1 }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-unsorted { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-sort }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-desc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-sort-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-asc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-sort-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-linkedin {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-linkedin { #{$fa-icon-property}: unquote("\"#{ $fa-var-linkedin-in }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-rotate-left { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-rotate-left }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-legal { #{$fa-icon-property}: unquote("\"#{ $fa-var-gavel }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-tachometer { #{$fa-icon-property}: unquote("\"#{ $fa-var-gauge-high }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dashboard { #{$fa-icon-property}: unquote("\"#{ $fa-var-gauge-high }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-comment-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-linkedin { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-linkedin-in }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-rotate-left { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-rotate-left }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-legal { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-gavel }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-tachometer { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-gauge-high }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dashboard { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-gauge-high }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-comment-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-comment-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-comment }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-comments-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-comment-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-comment }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-comments-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-comments-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-comments }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-flash { #{$fa-icon-property}: unquote("\"#{ $fa-var-bolt }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-clipboard { #{$fa-icon-property}: unquote("\"#{ $fa-var-paste }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-lightbulb-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-comments-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-comments }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-flash { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bolt }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-clipboard { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-paste }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-lightbulb-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-lightbulb-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-lightbulb }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-exchange { #{$fa-icon-property}: unquote("\"#{ $fa-var-right-left }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cloud-download { #{$fa-icon-property}: unquote("\"#{ $fa-var-cloud-arrow-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cloud-upload { #{$fa-icon-property}: unquote("\"#{ $fa-var-cloud-arrow-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bell-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-lightbulb-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-lightbulb }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-exchange { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-right-left }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cloud-download { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-cloud-arrow-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cloud-upload { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-cloud-arrow-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bell-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bell-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-bell }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cutlery { #{$fa-icon-property}: unquote("\"#{ $fa-var-utensils }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-text-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bell-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bell }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cutlery { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-utensils }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-text-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-text-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-lines }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-building-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-text-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-lines }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-building-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-building-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-building }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hospital-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-building-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-building }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hospital-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hospital-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hospital }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-tablet { #{$fa-icon-property}: unquote("\"#{ $fa-var-tablet-screen-button }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-mobile { #{$fa-icon-property}: unquote("\"#{ $fa-var-mobile-screen-button }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-mobile-phone { #{$fa-icon-property}: unquote("\"#{ $fa-var-mobile-screen-button }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hospital-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hospital }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-tablet { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-tablet-screen-button }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-mobile { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-mobile-screen-button }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-mobile-phone { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-mobile-screen-button }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-mail-reply { #{$fa-icon-property}: unquote("\"#{ $fa-var-reply }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-github-alt {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-mail-reply { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-reply }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-github-alt {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-folder-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-folder-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-folder-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-folder }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-folder-open-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-folder-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-folder }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-folder-open-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-folder-open-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-folder-open }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-smile-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-folder-open-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-folder-open }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-smile-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-smile-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-face-smile }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-frown-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-smile-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-face-smile }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-frown-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-frown-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-face-frown }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-meh-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-frown-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-face-frown }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-meh-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-meh-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-face-meh }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-keyboard-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-meh-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-face-meh }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-keyboard-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-keyboard-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-keyboard }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-flag-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-keyboard-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-keyboard }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-flag-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-flag-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-flag }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-mail-reply-all { #{$fa-icon-property}: unquote("\"#{ $fa-var-reply-all }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-half-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-flag-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-flag }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-mail-reply-all { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-reply-all }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-half-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-half-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-star-half-stroke }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-half-empty {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-half-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-star-half-stroke }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-half-empty {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-half-empty { #{$fa-icon-property}: unquote("\"#{ $fa-var-star-half-stroke }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-half-full {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-half-empty { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-star-half-stroke }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-half-full {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-star-half-full { #{$fa-icon-property}: unquote("\"#{ $fa-var-star-half-stroke }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-code-fork { #{$fa-icon-property}: unquote("\"#{ $fa-var-code-branch }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-chain-broken { #{$fa-icon-property}: unquote("\"#{ $fa-var-link-slash }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-unlink { #{$fa-icon-property}: unquote("\"#{ $fa-var-link-slash }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-star-half-full { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-star-half-stroke }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-code-fork { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-code-branch }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-chain-broken { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-link-slash }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-unlink { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-link-slash }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-calendar }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-maxcdn {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-calendar }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-maxcdn {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-html5 {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-html5 {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-css3 {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-css3 {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-unlock-alt { #{$fa-icon-property}: unquote("\"#{ $fa-var-unlock }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-minus-square-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-unlock-alt { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-unlock }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-minus-square-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-minus-square-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-minus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-level-up { #{$fa-icon-property}: unquote("\"#{ $fa-var-turn-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-level-down { #{$fa-icon-property}: unquote("\"#{ $fa-var-turn-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pencil-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-pen }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-external-link-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-up-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-compass {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-minus-square-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-minus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-level-up { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-turn-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-level-down { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-turn-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pencil-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-pen }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-external-link-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-up-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-compass {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-down {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-down {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-down { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-down {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-down { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-down {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-down { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-down }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-up {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-down { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-down }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-up {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-up { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-up {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-up { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-up {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-up { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-up }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-right {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-up { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-up }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-right {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-right { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-right {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-right { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-right {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-right { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-eur { #{$fa-icon-property}: unquote("\"#{ $fa-var-euro-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-euro { #{$fa-icon-property}: unquote("\"#{ $fa-var-euro-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gbp { #{$fa-icon-property}: unquote("\"#{ $fa-var-sterling-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-usd { #{$fa-icon-property}: unquote("\"#{ $fa-var-dollar-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dollar { #{$fa-icon-property}: unquote("\"#{ $fa-var-dollar-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-inr { #{$fa-icon-property}: unquote("\"#{ $fa-var-indian-rupee-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-rupee { #{$fa-icon-property}: unquote("\"#{ $fa-var-indian-rupee-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-jpy { #{$fa-icon-property}: unquote("\"#{ $fa-var-yen-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cny { #{$fa-icon-property}: unquote("\"#{ $fa-var-yen-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-rmb { #{$fa-icon-property}: unquote("\"#{ $fa-var-yen-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yen { #{$fa-icon-property}: unquote("\"#{ $fa-var-yen-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-rub { #{$fa-icon-property}: unquote("\"#{ $fa-var-ruble-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ruble { #{$fa-icon-property}: unquote("\"#{ $fa-var-ruble-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-rouble { #{$fa-icon-property}: unquote("\"#{ $fa-var-ruble-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-krw { #{$fa-icon-property}: unquote("\"#{ $fa-var-won-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-won { #{$fa-icon-property}: unquote("\"#{ $fa-var-won-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-btc {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-right { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-eur { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-euro-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-euro { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-euro-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gbp { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-sterling-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-usd { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-dollar-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dollar { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-dollar-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-inr { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-indian-rupee-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-rupee { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-indian-rupee-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-jpy { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-yen-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cny { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-yen-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-rmb { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-yen-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yen { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-yen-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-rub { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-ruble-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ruble { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-ruble-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-rouble { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-ruble-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-krw { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-won-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-won { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-won-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-btc {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bitcoin {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bitcoin {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bitcoin { #{$fa-icon-property}: unquote("\"#{ $fa-var-btc }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-text { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-lines }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-alpha-asc { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-down-a-z }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-alpha-desc { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-down-z-a }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-amount-asc { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-down-short-wide }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-amount-desc { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-down-wide-short }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-numeric-asc { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-down-1-9 }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sort-numeric-desc { #{$fa-icon-property}: unquote("\"#{ $fa-var-arrow-down-9-1 }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-youtube-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bitcoin { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-btc }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-text { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-lines }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-alpha-asc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-down-a-z }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-alpha-desc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-down-z-a }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-amount-asc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-down-short-wide }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-amount-desc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-down-wide-short }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-numeric-asc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-down-1-9 }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sort-numeric-desc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-arrow-down-9-1 }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-youtube-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-youtube-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-youtube }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-youtube {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-youtube-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-youtube }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-youtube {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-xing {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-xing {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-xing-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-xing-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-xing-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-xing }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-youtube-play {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-xing-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-xing }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-youtube-play {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-youtube-play { #{$fa-icon-property}: unquote("\"#{ $fa-var-youtube }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dropbox {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-youtube-play { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-youtube }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dropbox {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-stack-overflow {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-stack-overflow {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-instagram {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-instagram {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-flickr {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-flickr {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-adn {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-adn {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bitbucket {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bitbucket {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bitbucket-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bitbucket-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bitbucket-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-bitbucket }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-tumblr {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bitbucket-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bitbucket }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-tumblr {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-tumblr-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-tumblr-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-tumblr-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-tumblr }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-long-arrow-down { #{$fa-icon-property}: unquote("\"#{ $fa-var-down-long }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-long-arrow-up { #{$fa-icon-property}: unquote("\"#{ $fa-var-up-long }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-long-arrow-left { #{$fa-icon-property}: unquote("\"#{ $fa-var-left-long }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-long-arrow-right { #{$fa-icon-property}: unquote("\"#{ $fa-var-right-long }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-apple {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-tumblr-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-tumblr }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-long-arrow-down { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-down-long }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-long-arrow-up { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-up-long }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-long-arrow-left { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-left-long }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-long-arrow-right { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-right-long }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-apple {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-windows {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-windows {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-android {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-android {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-linux {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-linux {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dribbble {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dribbble {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-skype {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-skype {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-foursquare {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-foursquare {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-trello {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-trello {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gratipay {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gratipay {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gittip {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gittip {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gittip { #{$fa-icon-property}: unquote("\"#{ $fa-var-gratipay }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sun-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gittip { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-gratipay }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sun-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sun-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-sun }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-moon-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sun-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-sun }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-moon-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-moon-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-moon }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vk {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-moon-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-moon }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vk {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-weibo {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-weibo {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-renren {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-renren {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pagelines {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pagelines {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-stack-exchange {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-stack-exchange {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-right {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-right {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-right { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-right }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-left {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-right { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-right }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-left {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-arrow-circle-o-left { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-left }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-left {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-arrow-circle-o-left { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-left }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-left {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-caret-square-o-left { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-left }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-left {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-caret-square-o-left { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-left }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-left {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-toggle-left { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-caret-left }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dot-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-toggle-left { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-caret-left }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dot-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dot-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-dot }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vimeo-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dot-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-dot }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vimeo-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vimeo-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-vimeo }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-try { #{$fa-icon-property}: unquote("\"#{ $fa-var-turkish-lira-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-turkish-lira { #{$fa-icon-property}: unquote("\"#{ $fa-var-turkish-lira-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-plus-square-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vimeo-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-vimeo }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-try { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-turkish-lira-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-turkish-lira { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-turkish-lira-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-plus-square-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-plus-square-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-plus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-slack {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-plus-square-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-plus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-slack {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wordpress {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wordpress {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-openid {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-openid {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-institution { #{$fa-icon-property}: unquote("\"#{ $fa-var-building-columns }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bank { #{$fa-icon-property}: unquote("\"#{ $fa-var-building-columns }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-mortar-board { #{$fa-icon-property}: unquote("\"#{ $fa-var-graduation-cap }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yahoo {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-institution { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-building-columns }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bank { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-building-columns }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-mortar-board { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-graduation-cap }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yahoo {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-reddit {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-reddit {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-reddit-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-reddit-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-reddit-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-reddit }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-stumbleupon-circle {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-reddit-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-reddit }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-stumbleupon-circle {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-stumbleupon {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-stumbleupon {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-delicious {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-delicious {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-digg {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-digg {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pied-piper-pp {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pied-piper-pp {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pied-piper-alt {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pied-piper-alt {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-drupal {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-drupal {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-joomla {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-joomla {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-behance {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-behance {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-behance-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-behance-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-behance-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-behance }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-steam {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-behance-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-behance }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-steam {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-steam-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-steam-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-steam-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-steam }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-automobile { #{$fa-icon-property}: unquote("\"#{ $fa-var-car }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cab { #{$fa-icon-property}: unquote("\"#{ $fa-var-taxi }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-spotify {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-steam-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-steam }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-automobile { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-car }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cab { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-taxi }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-spotify {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-deviantart {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-deviantart {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-soundcloud {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-soundcloud {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-pdf-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-pdf-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-pdf-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-pdf }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-word-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-pdf-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-pdf }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-word-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-word-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-word }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-excel-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-word-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-word }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-excel-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-excel-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-excel }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-powerpoint-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-excel-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-excel }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-powerpoint-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-powerpoint-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-powerpoint }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-image-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-powerpoint-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-powerpoint }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-image-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-image-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-image }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-photo-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-image-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-image }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-photo-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-photo-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-image }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-picture-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-photo-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-image }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-picture-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-picture-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-image }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-archive-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-picture-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-image }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-archive-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-archive-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-zipper }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-zip-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-archive-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-zipper }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-zip-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-zip-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-zipper }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-audio-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-zip-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-zipper }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-audio-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-audio-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-audio }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-sound-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-audio-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-audio }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-sound-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-sound-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-audio }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-video-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-sound-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-audio }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-video-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-video-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-video }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-movie-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-video-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-video }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-movie-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-movie-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-video }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-code-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-movie-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-video }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-code-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-file-code-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-file-code }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vine {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-file-code-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-file-code }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vine {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-codepen {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-codepen {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-jsfiddle {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-jsfiddle {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-life-bouy { #{$fa-icon-property}: unquote("\"#{ $fa-var-life-ring }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-life-buoy { #{$fa-icon-property}: unquote("\"#{ $fa-var-life-ring }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-life-saver { #{$fa-icon-property}: unquote("\"#{ $fa-var-life-ring }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-support { #{$fa-icon-property}: unquote("\"#{ $fa-var-life-ring }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-circle-o-notch { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-notch }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-rebel {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-life-bouy { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-life-ring }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-life-buoy { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-life-ring }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-life-saver { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-life-ring }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-support { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-life-ring }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-circle-o-notch { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-notch }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-rebel {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ra {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ra {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ra { #{$fa-icon-property}: unquote("\"#{ $fa-var-rebel }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-resistance {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ra { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-rebel }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-resistance {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-resistance { #{$fa-icon-property}: unquote("\"#{ $fa-var-rebel }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-empire {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-resistance { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-rebel }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-empire {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ge {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ge {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ge { #{$fa-icon-property}: unquote("\"#{ $fa-var-empire }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-git-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ge { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-empire }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-git-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-git-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-git }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-git {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-git-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-git }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-git {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hacker-news {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hacker-news {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-y-combinator-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-y-combinator-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-y-combinator-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-hacker-news }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yc-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-y-combinator-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hacker-news }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yc-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yc-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-hacker-news }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-tencent-weibo {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yc-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hacker-news }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-tencent-weibo {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-qq {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-qq {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-weixin {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-weixin {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wechat {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wechat {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wechat { #{$fa-icon-property}: unquote("\"#{ $fa-var-weixin }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-send { #{$fa-icon-property}: unquote("\"#{ $fa-var-paper-plane }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-paper-plane-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wechat { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-weixin }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-send { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-paper-plane }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-paper-plane-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-paper-plane-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-paper-plane }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-send-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-paper-plane-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-paper-plane }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-send-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-send-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-paper-plane }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-circle-thin {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-send-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-paper-plane }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-circle-thin {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-circle-thin { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-header { #{$fa-icon-property}: unquote("\"#{ $fa-var-heading }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-futbol-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-circle-thin { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-header { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-heading }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-futbol-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-futbol-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-futbol }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-soccer-ball-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-futbol-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-futbol }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-soccer-ball-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-soccer-ball-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-futbol }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-slideshare {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-soccer-ball-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-futbol }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-slideshare {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-twitch {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-twitch {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yelp {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yelp {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-newspaper-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-newspaper-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-newspaper-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-newspaper }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-paypal {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-newspaper-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-newspaper }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-paypal {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-wallet {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-wallet {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-visa {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-visa {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-mastercard {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-mastercard {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-discover {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-discover {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-amex {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-amex {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-paypal {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-paypal {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-stripe {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-stripe {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bell-slash-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bell-slash-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bell-slash-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-bell-slash }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-trash { #{$fa-icon-property}: unquote("\"#{ $fa-var-trash-can }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-copyright {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bell-slash-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bell-slash }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-trash { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-trash-can }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-copyright {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-eyedropper { #{$fa-icon-property}: unquote("\"#{ $fa-var-eye-dropper }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-area-chart { #{$fa-icon-property}: unquote("\"#{ $fa-var-chart-area }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pie-chart { #{$fa-icon-property}: unquote("\"#{ $fa-var-chart-pie }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-line-chart { #{$fa-icon-property}: unquote("\"#{ $fa-var-chart-line }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-lastfm {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-eyedropper { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-eye-dropper }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-area-chart { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-chart-area }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pie-chart { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-chart-pie }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-line-chart { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-chart-line }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-lastfm {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-lastfm-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-lastfm-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-lastfm-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-lastfm }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ioxhost {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-lastfm-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-lastfm }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ioxhost {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-angellist {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-angellist {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc { #{$fa-icon-property}: unquote("\"#{ $fa-var-closed-captioning }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ils { #{$fa-icon-property}: unquote("\"#{ $fa-var-shekel-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-shekel { #{$fa-icon-property}: unquote("\"#{ $fa-var-shekel-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sheqel { #{$fa-icon-property}: unquote("\"#{ $fa-var-shekel-sign }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-buysellads {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-closed-captioning }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ils { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-shekel-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-shekel { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-shekel-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sheqel { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-shekel-sign }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-buysellads {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-connectdevelop {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-connectdevelop {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-dashcube {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-dashcube {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-forumbee {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-forumbee {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-leanpub {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-leanpub {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sellsy {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sellsy {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-shirtsinbulk {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-shirtsinbulk {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-simplybuilt {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-simplybuilt {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-skyatlas {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-skyatlas {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-diamond {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-diamond {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-diamond { #{$fa-icon-property}: unquote("\"#{ $fa-var-gem }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-transgender { #{$fa-icon-property}: unquote("\"#{ $fa-var-mars-and-venus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-intersex { #{$fa-icon-property}: unquote("\"#{ $fa-var-mars-and-venus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-transgender-alt { #{$fa-icon-property}: unquote("\"#{ $fa-var-transgender }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook-official {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-diamond { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-gem }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-transgender { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-mars-and-venus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-intersex { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-mars-and-venus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-transgender-alt { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-transgender }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook-official {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-facebook-official { #{$fa-icon-property}: unquote("\"#{ $fa-var-facebook }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pinterest-p {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-facebook-official { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-facebook }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pinterest-p {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-whatsapp {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-whatsapp {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hotel { #{$fa-icon-property}: unquote("\"#{ $fa-var-bed }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-viacoin {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hotel { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bed }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-viacoin {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-medium {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-medium {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-y-combinator {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-y-combinator {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yc {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yc {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yc { #{$fa-icon-property}: unquote("\"#{ $fa-var-y-combinator }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-optin-monster {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yc { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-y-combinator }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-optin-monster {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-opencart {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-opencart {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-expeditedssl {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-expeditedssl {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-battery-4 { #{$fa-icon-property}: unquote("\"#{ $fa-var-battery-full }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-battery { #{$fa-icon-property}: unquote("\"#{ $fa-var-battery-full }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-battery-3 { #{$fa-icon-property}: unquote("\"#{ $fa-var-battery-three-quarters }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-battery-2 { #{$fa-icon-property}: unquote("\"#{ $fa-var-battery-half }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-battery-1 { #{$fa-icon-property}: unquote("\"#{ $fa-var-battery-quarter }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-battery-0 { #{$fa-icon-property}: unquote("\"#{ $fa-var-battery-empty }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-object-group {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-battery-4 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-battery-full }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-battery { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-battery-full }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-battery-3 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-battery-three-quarters }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-battery-2 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-battery-half }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-battery-1 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-battery-quarter }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-battery-0 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-battery-empty }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-object-group {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-object-ungroup {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-object-ungroup {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sticky-note-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sticky-note-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-sticky-note-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-note-sticky }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-jcb {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-sticky-note-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-note-sticky }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-jcb {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-cc-diners-club {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-cc-diners-club {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-clone {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-clone {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hourglass-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hourglass }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hourglass-1 { #{$fa-icon-property}: unquote("\"#{ $fa-var-hourglass-start }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hourglass-2 { #{$fa-icon-property}: unquote("\"#{ $fa-var-hourglass-half }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hourglass-3 { #{$fa-icon-property}: unquote("\"#{ $fa-var-hourglass-end }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-rock-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hourglass-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hourglass }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hourglass-1 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hourglass-start }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hourglass-2 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hourglass-half }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hourglass-3 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hourglass-end }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-rock-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-rock-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-back-fist }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-grab-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-rock-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-back-fist }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-grab-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-grab-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-back-fist }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-paper-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-grab-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-back-fist }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-paper-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-paper-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-stop-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-paper-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-stop-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-stop-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-scissors-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-stop-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-scissors-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-scissors-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-scissors }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-lizard-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-scissors-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-scissors }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-lizard-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-lizard-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-lizard }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-spock-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-lizard-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-lizard }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-spock-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-spock-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-spock }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-pointer-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-spock-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-spock }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-pointer-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-pointer-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-pointer }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-peace-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-pointer-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-pointer }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-peace-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hand-peace-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-hand-peace }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-registered {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hand-peace-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hand-peace }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-registered {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-creative-commons {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-creative-commons {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gg {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gg {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gg-circle {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gg-circle {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-odnoklassniki {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-odnoklassniki {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-odnoklassniki-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-odnoklassniki-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-odnoklassniki-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-odnoklassniki }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-get-pocket {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-odnoklassniki-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-odnoklassniki }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-get-pocket {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wikipedia-w {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wikipedia-w {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-safari {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-safari {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-chrome {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-chrome {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-firefox {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-firefox {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-opera {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-opera {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-internet-explorer {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-internet-explorer {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-television { #{$fa-icon-property}: unquote("\"#{ $fa-var-tv }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-contao {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-television { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-tv }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-contao {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-500px {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-500px {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-amazon {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-amazon {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-plus-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-plus-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-plus-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-calendar-plus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-minus-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-plus-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-calendar-plus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-minus-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-minus-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-calendar-minus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-times-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-minus-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-calendar-minus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-times-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-times-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-calendar-xmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-check-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-times-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-calendar-xmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-check-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-calendar-check-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-calendar-check }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-map-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-calendar-check-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-calendar-check }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-map-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-map-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-map }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-commenting { #{$fa-icon-property}: unquote("\"#{ $fa-var-comment-dots }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-commenting-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-map-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-map }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-commenting { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-comment-dots }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-commenting-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-commenting-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-comment-dots }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-houzz {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-commenting-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-comment-dots }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-houzz {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vimeo {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vimeo {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vimeo { #{$fa-icon-property}: unquote("\"#{ $fa-var-vimeo-v }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-black-tie {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vimeo { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-vimeo-v }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-black-tie {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-fonticons {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-fonticons {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-reddit-alien {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-reddit-alien {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-edge {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-edge {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-credit-card-alt { #{$fa-icon-property}: unquote("\"#{ $fa-var-credit-card }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-codiepie {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-credit-card-alt { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-credit-card }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-codiepie {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-modx {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-modx {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-fort-awesome {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-fort-awesome {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-usb {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-usb {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-product-hunt {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-product-hunt {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-mixcloud {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-mixcloud {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-scribd {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-scribd {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pause-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pause-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pause-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-pause }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-stop-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pause-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-pause }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-stop-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-stop-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-stop }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bluetooth {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-stop-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-stop }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bluetooth {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bluetooth-b {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bluetooth-b {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-gitlab {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-gitlab {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wpbeginner {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wpbeginner {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wpforms {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wpforms {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-envira {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-envira {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wheelchair-alt {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wheelchair-alt {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wheelchair-alt { #{$fa-icon-property}: unquote("\"#{ $fa-var-accessible-icon }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-question-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wheelchair-alt { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-accessible-icon }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-question-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-question-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-question }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-volume-control-phone { #{$fa-icon-property}: unquote("\"#{ $fa-var-phone-volume }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-asl-interpreting { #{$fa-icon-property}: unquote("\"#{ $fa-var-hands-asl-interpreting }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-deafness { #{$fa-icon-property}: unquote("\"#{ $fa-var-ear-deaf }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-hard-of-hearing { #{$fa-icon-property}: unquote("\"#{ $fa-var-ear-deaf }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-glide {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-question-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-question }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-volume-control-phone { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-phone-volume }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-asl-interpreting { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hands-asl-interpreting }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-deafness { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-ear-deaf }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-hard-of-hearing { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-ear-deaf }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-glide {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-glide-g {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-glide-g {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-signing { #{$fa-icon-property}: unquote("\"#{ $fa-var-hands }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-viadeo {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-signing { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-hands }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-viadeo {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-viadeo-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-viadeo-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-viadeo-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-viadeo }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-snapchat {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-viadeo-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-viadeo }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-snapchat {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-snapchat-ghost {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-snapchat-ghost {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-snapchat-ghost { #{$fa-icon-property}: unquote("\"#{ $fa-var-snapchat }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-snapchat-square {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-snapchat-ghost { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-snapchat }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-snapchat-square {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-snapchat-square { #{$fa-icon-property}: unquote("\"#{ $fa-var-square-snapchat }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-pied-piper {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-snapchat-square { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-square-snapchat }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-pied-piper {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-first-order {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-first-order {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-yoast {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-yoast {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-themeisle {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-themeisle {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus-official {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus-official {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus-official { #{$fa-icon-property}: unquote("\"#{ $fa-var-google-plus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus-circle {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus-official { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-google-plus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus-circle {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-google-plus-circle { #{$fa-icon-property}: unquote("\"#{ $fa-var-google-plus }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-font-awesome {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-google-plus-circle { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-google-plus }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-font-awesome {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-fa {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-fa {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-fa { #{$fa-icon-property}: unquote("\"#{ $fa-var-font-awesome }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-handshake-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-fa { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-font-awesome }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-handshake-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-handshake-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-handshake }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-envelope-open-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-handshake-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-handshake }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-envelope-open-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-envelope-open-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-envelope-open }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-linode {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-envelope-open-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-envelope-open }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-linode {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-address-book-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-address-book-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-address-book-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-address-book }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vcard { #{$fa-icon-property}: unquote("\"#{ $fa-var-address-card }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-address-card-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-address-book-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-address-book }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vcard { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-address-card }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-address-card-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-address-card-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-address-card }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vcard-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-address-card-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-address-card }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vcard-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-vcard-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-address-card }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-user-circle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-vcard-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-address-card }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-user-circle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-user-circle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-circle-user }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-user-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-user-circle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-circle-user }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-user-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-user-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-user }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-id-badge {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-user-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-user }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-id-badge {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-drivers-license { #{$fa-icon-property}: unquote("\"#{ $fa-var-id-card }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-id-card-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-drivers-license { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-id-card }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-id-card-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-id-card-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-id-card }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-drivers-license-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-id-card-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-id-card }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-drivers-license-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-drivers-license-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-id-card }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-quora {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-drivers-license-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-id-card }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-quora {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-free-code-camp {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-free-code-camp {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-telegram {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-telegram {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thermometer-4 { #{$fa-icon-property}: unquote("\"#{ $fa-var-temperature-full }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thermometer { #{$fa-icon-property}: unquote("\"#{ $fa-var-temperature-full }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thermometer-3 { #{$fa-icon-property}: unquote("\"#{ $fa-var-temperature-three-quarters }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thermometer-2 { #{$fa-icon-property}: unquote("\"#{ $fa-var-temperature-half }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thermometer-1 { #{$fa-icon-property}: unquote("\"#{ $fa-var-temperature-quarter }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-thermometer-0 { #{$fa-icon-property}: unquote("\"#{ $fa-var-temperature-empty }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bathtub { #{$fa-icon-property}: unquote("\"#{ $fa-var-bath }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-s15 { #{$fa-icon-property}: unquote("\"#{ $fa-var-bath }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-window-maximize {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thermometer-4 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-temperature-full }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thermometer { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-temperature-full }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thermometer-3 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-temperature-three-quarters }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thermometer-2 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-temperature-half }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thermometer-1 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-temperature-quarter }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-thermometer-0 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-temperature-empty }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bathtub { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bath }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-s15 { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-bath }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-window-maximize {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-window-restore {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-window-restore {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-times-rectangle { #{$fa-icon-property}: unquote("\"#{ $fa-var-rectangle-xmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-window-close-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-times-rectangle { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-rectangle-xmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-window-close-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-window-close-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-rectangle-xmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-times-rectangle-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-window-close-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-rectangle-xmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-times-rectangle-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-times-rectangle-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-rectangle-xmark }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-bandcamp {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-times-rectangle-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-rectangle-xmark }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-bandcamp {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-grav {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-grav {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-etsy {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-etsy {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-imdb {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-imdb {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-ravelry {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-ravelry {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-eercast {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-eercast {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-eercast { #{$fa-icon-property}: unquote("\"#{ $fa-var-sellcast }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-snowflake-o {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-eercast { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-sellcast }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-snowflake-o {
   font-family: 'Font Awesome 6 Free';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-snowflake-o { #{$fa-icon-property}: unquote("\"#{ $fa-var-snowflake }\""); }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-superpowers {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-snowflake-o { #{variables.$fa-icon-property}: string.unquote("\"#{ variables.$fa-var-snowflake }\""); }
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-superpowers {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-wpexplorer {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-wpexplorer {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }
-.#{$fa-css-prefix}.#{$fa-css-prefix}-meetup {
+.#{variables.$fa-css-prefix}.#{variables.$fa-css-prefix}-meetup {
   font-family: 'Font Awesome 6 Brands';
   font-weight: 400;
 }

--- a/_sass/external/font-awesome/_sizing.scss
+++ b/_sass/external/font-awesome/_sizing.scss
@@ -1,16 +1,19 @@
+@use "mixins";
+@use "variables";
+
 // sizing icons
 // -------------------------
 
 // literal magnification scale
 @for $i from 1 through 10 {
-  .#{$fa-css-prefix}-#{$i}x {
+  .#{variables.$fa-css-prefix}-#{$i}x {
     font-size: $i * 1em;
   }
 }
 
 // step-based scale (with alignment)
-@each $size, $value in $fa-sizes {
-  .#{$fa-css-prefix}-#{$size} {
-     @include fa-size($value);
+@each $size, $value in variables.$fa-sizes {
+  .#{variables.$fa-css-prefix}-#{$size} {
+     @include mixins.fa-size($value);
   }
 }

--- a/_sass/external/font-awesome/_stacked.scss
+++ b/_sass/external/font-awesome/_stacked.scss
@@ -1,32 +1,34 @@
+@use "variables";
+
 // stacking icons
 // -------------------------
 
-.#{$fa-css-prefix}-stack {
+.#{variables.$fa-css-prefix}-stack {
   display: inline-block;
   height: 2em;
   line-height: 2em;
   position: relative;
-  vertical-align: $fa-stack-vertical-align;
-  width: $fa-stack-width;
+  vertical-align: variables.$fa-stack-vertical-align;
+  width: variables.$fa-stack-width;
 }
 
-.#{$fa-css-prefix}-stack-1x,
-.#{$fa-css-prefix}-stack-2x {
+.#{variables.$fa-css-prefix}-stack-1x,
+.#{variables.$fa-css-prefix}-stack-2x {
   left: 0;
   position: absolute;
   text-align: center;
   width: 100%;
-  z-index: var(--#{$fa-css-prefix}-stack-z-index, #{$fa-stack-z-index});
+  z-index: var(--#{variables.$fa-css-prefix}-stack-z-index, #{variables.$fa-stack-z-index});
 }
 
-.#{$fa-css-prefix}-stack-1x {
+.#{variables.$fa-css-prefix}-stack-1x {
   line-height: inherit;
 }
 
-.#{$fa-css-prefix}-stack-2x {
+.#{variables.$fa-css-prefix}-stack-2x {
   font-size: 2em;
 }
 
-.#{$fa-css-prefix}-inverse {
-  color: var(--#{$fa-css-prefix}-inverse, #{$fa-inverse});
+.#{variables.$fa-css-prefix}-inverse {
+  color: var(--#{variables.$fa-css-prefix}-inverse, #{variables.$fa-inverse});
 }

--- a/_sass/external/font-awesome/_variables.scss
+++ b/_sass/external/font-awesome/_variables.scss
@@ -1,3 +1,5 @@
+@use "functions";
+
 // variables
 // --------------------------
 
@@ -10,7 +12,7 @@ $fa-duotone-icon-property : --fa--fa;
 
 $fa-display               : inline-block !default;
 
-$fa-fw-width              : fa-divide(20em, 16) !default;
+$fa-fw-width              : functions.fa-divide(20em, 16) !default;
 $fa-inverse               : #fff !default;
 
 $fa-border-color          : #eee !default;
@@ -37,7 +39,7 @@ $fa-sizes: (
 ) !default;
 
 $fa-li-width              : 2em !default;
-$fa-li-margin             : $fa-li-width * fa-divide(5, 4) !default;
+$fa-li-margin             : $fa-li-width * functions.fa-divide(5, 4) !default;
 
 $fa-pull-margin           : .3em !default;
 

--- a/_sass/external/font-awesome/brands.scss
+++ b/_sass/external/font-awesome/brands.scss
@@ -3,28 +3,30 @@
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  * Copyright 2024 Fonticons, Inc.
  */
-@import 'functions';
-@import 'variables';
+@use "sass:string";
+@use 'functions';
+@forward 'variables' show $fa-inverse, $fa-font-path;
+@use 'variables';
 
 :root, :host {
-  --#{$fa-css-prefix}-style-family-brands: 'Font Awesome 6 Brands';
-  --#{$fa-css-prefix}-font-brands: normal 400 1em/1 'Font Awesome 6 Brands';
+  --#{variables.$fa-css-prefix}-style-family-brands: 'Font Awesome 6 Brands';
+  --#{variables.$fa-css-prefix}-font-brands: normal 400 1em/1 'Font Awesome 6 Brands';
 }
 
 @font-face {
   font-family: 'Font Awesome 6 Brands';
   font-style: normal;
   font-weight: 400;
-  font-display: $fa-font-display;
-  src: url('#{$fa-font-path}/fa-brands-400.woff2') format('woff2'),
-    url('#{$fa-font-path}/fa-brands-400.ttf') format('truetype');
+  font-display: variables.$fa-font-display;
+  src: url('#{variables.$fa-font-path}/fa-brands-400.woff2') format('woff2'),
+    url('#{variables.$fa-font-path}/fa-brands-400.ttf') format('truetype');
 }
 
 .fab,
-.#{$fa-css-prefix}-brands {
+.#{variables.$fa-css-prefix}-brands {
   font-weight: 400;
 }
 
-@each $name, $icon in $fa-brand-icons {
-  .#{$fa-css-prefix}-#{$name} { #{$fa-icon-property}: unquote("\"#{ $icon }\""); }
+@each $name, $icon in variables.$fa-brand-icons {
+  .#{variables.$fa-css-prefix}-#{$name} { #{variables.$fa-icon-property}: string.unquote("\"#{ $icon }\""); }
 }

--- a/_sass/external/font-awesome/fontawesome.scss
+++ b/_sass/external/font-awesome/fontawesome.scss
@@ -6,16 +6,16 @@
 // Font Awesome core compile (Web Fonts-based)
 // -------------------------
 
-@import 'functions';
-@import 'variables';
-@import 'mixins';
-@import 'core';
-@import 'sizing';
-@import 'fixed-width';
-@import 'list';
-@import 'bordered-pulled';
-@import 'animated';
-@import 'rotated-flipped';
-@import 'stacked';
-@import 'icons';
-@import 'screen-reader';
+@use 'functions';
+@forward 'variables' show $fa-inverse, $fa-font-path;
+@use 'mixins';
+@use 'core';
+@use 'sizing';
+@use 'fixed-width';
+@use 'list';
+@use 'bordered-pulled';
+@use 'animated';
+@use 'rotated-flipped';
+@use 'stacked';
+@use 'icons';
+@use 'screen-reader';

--- a/_sass/external/font-awesome/regular.scss
+++ b/_sass/external/font-awesome/regular.scss
@@ -3,12 +3,13 @@
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  * Copyright 2024 Fonticons, Inc.
  */
-@import 'functions';
-@import 'variables';
+@use 'functions';
+@forward 'variables' show $fa-inverse, $fa-font-path;
+@use 'variables';
 
 :root, :host {
-  --#{$fa-css-prefix}-style-family-classic: '#{ $fa-style-family }';
-  --#{$fa-css-prefix}-font-regular: normal 400 1em/1 '#{ $fa-style-family }';
+  --#{variables.$fa-css-prefix}-style-family-classic: '#{ variables.$fa-style-family }';
+  --#{variables.$fa-css-prefix}-font-regular: normal 400 1em/1 '#{ variables.$fa-style-family }';
 }
 
 
@@ -16,12 +17,12 @@
   font-family: 'Font Awesome 6 Free';
   font-style: normal;
   font-weight: 400;
-  font-display: $fa-font-display;
-  src: url('#{$fa-font-path}/fa-regular-400.woff2') format('woff2'),
-    url('#{$fa-font-path}/fa-regular-400.ttf') format('truetype');
+  font-display: variables.$fa-font-display;
+  src: url('#{variables.$fa-font-path}/fa-regular-400.woff2') format('woff2'),
+    url('#{variables.$fa-font-path}/fa-regular-400.ttf') format('truetype');
 }
 
 .far,
-.#{$fa-css-prefix}-regular {
+.#{variables.$fa-css-prefix}-regular {
   font-weight: 400;
 }

--- a/_sass/external/font-awesome/solid.scss
+++ b/_sass/external/font-awesome/solid.scss
@@ -3,12 +3,13 @@
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  * Copyright 2024 Fonticons, Inc.
  */
-@import 'functions';
-@import 'variables';
+@use 'functions';
+@forward 'variables' show $fa-inverse, $fa-font-path;
+@use 'variables';
 
 :root, :host {
-  --#{$fa-css-prefix}-style-family-classic: '#{ $fa-style-family }';
-  --#{$fa-css-prefix}-font-solid: normal 900 1em/1 '#{ $fa-style-family }';
+  --#{variables.$fa-css-prefix}-style-family-classic: '#{ variables.$fa-style-family }';
+  --#{variables.$fa-css-prefix}-font-solid: normal 900 1em/1 '#{ variables.$fa-style-family }';
 }
 
 
@@ -16,12 +17,12 @@
   font-family: 'Font Awesome 6 Free';
   font-style: normal;
   font-weight: 900;
-  font-display: $fa-font-display;
-  src: url('#{$fa-font-path}/fa-solid-900.woff2') format('woff2'),
-    url('#{$fa-font-path}/fa-solid-900.ttf') format('truetype');
+  font-display: variables.$fa-font-display;
+  src: url('#{variables.$fa-font-path}/fa-solid-900.woff2') format('woff2'),
+    url('#{variables.$fa-font-path}/fa-solid-900.ttf') format('truetype');
 }
 
 .fas,
-.#{$fa-css-prefix}-solid {
+.#{variables.$fa-css-prefix}-solid {
   font-weight: 900;
 }

--- a/_sass/external/font-awesome/v4-shims.scss
+++ b/_sass/external/font-awesome/v4-shims.scss
@@ -6,6 +6,6 @@
 // V4 shims compile (Web Fonts-based)
 // -------------------------
 
-@import 'functions';
-@import 'variables';
-@import 'shims';
+@use 'functions';
+@forward 'variables' show $fa-inverse, $fa-font-path;
+@use 'shims';


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
Deprecation warning are being shown for fontawesome, but it's not planned to being removed before the next major release.
In the meanwhile, I have run the sass migration on fontawesome scss, and that should take care of all the remaining warning.

```
 sass-migrator module --migrate-deps _sass/external/_font-awesome.scss
```

Linked with #471 and #470 
