### PR TITLE
Quiet sass warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,7 @@ collections:
 # BUILD SETTINGS
 sass:
   style: compressed
+  quiet_deps: true
 plugins: [jekyll-paginate, jekyll-seo-tag, jekyll-feed]
 exclude: [".jekyll-cache", ".jekyll-metadata", ".idea", "vendor/*", "assets/node_modules/*"]
 


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
As the new `sass` syntax is not compatible with GitHub page I'll quiet the dependencies for now (Fix #470)
However one warning from the main.scss will still remain.
