### PR TITLE
Update ruby version ci tests

### DIFF
--- a/.github/workflows/gem-build.yml
+++ b/.github/workflows/gem-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '3.1', '3.2', '3.3' ]
+        ruby: [ '3.2', '3.3', '3.4' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gem-github-page.yml
+++ b/.github/workflows/gem-github-page.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.7.4', '3.0', '3.3' ]
+        ruby: [ '2.7.4', '3.1', '3.4' ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
Ruby 3.0 is not deprecated (still keeping 2.7.4 for github-page) but updating the rest.
