### PR TITLE
Navbar: Clear margin of the correct element when in the mobile layout

### DIFF
--- a/_sass/includes/_navbar.scss
+++ b/_sass/includes/_navbar.scss
@@ -138,7 +138,7 @@ nav {
       width: 100%;
       text-align: center;
       font-size: 1em;
-      position: relative;
+      margin: 0;
       background-color: var(--background);
       backdrop-filter: brightness(0.98);
 
@@ -148,7 +148,6 @@ nav {
 
       a {
         width: 100%;
-        margin: 0;
         display: block;
       }
 


### PR DESCRIPTION
### Description

Fixes a mistake I spotted while backporting a new mobile navbar to my blog - the mobile layouts cleared margins on a wrong element. It doesn't cause issues upstream because you use `margin-right`, but I switched it to `margin-left` and it made the navbar off-center.

Also, nowadays with `display: flow-root;` a clearfix could be removed. There is no need for tricks no longer, the navbar can be declared as a separate formatting context and floats will size this element accordingly:
https://github.com/CookiePLMonster/CookiePLMonster.github.io/blob/9140160a4dfab056bd8485901df6ba2f91f093a7/_sass/includes/_navbar.scss#L5

### Screenshot

No visual difference.
