### PR TITLE
add "last modified" date front matter

### DIFF
--- a/_includes/blog/post_info.liquid
+++ b/_includes/blog/post_info.liquid
@@ -12,4 +12,7 @@
       {{ site.data.language.str_months[x] | default: date | date: "%B" }} {{ date | date: "%d, %Y" }}
     </p>
   {%- if author.url -%}</a>{%- endif -%}
+  {% if include.last_modified %}
+    <p class="meta">Last updated: {{ include.last_modified | date: site.data.language.str_date_format | default: '%B %-d, %Y' }}</p>
+  {% endif %}
 </div>

--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -8,7 +8,7 @@ layout: default
                 <div class="feature-image-padding"></div>
             {% else %}
                 <h1 id="{{ page.title | cgi_escape }}" class="title">{{ page.title }}</h1>
-                {% include blog/post_info.liquid author=page.author date=page.date %}
+                {% include blog/post_info.liquid author=page.author date=page.date last_modified=page.last_modified %}
             {% endif %}
         </div>
     </header>

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -61,6 +61,7 @@ header {
   border-radius: 1em;
   padding-right: 0.5em;
   display: inline-flex;
+  flex-direction: column;
 
   a {
     display: flex;


### PR DESCRIPTION
<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
<!-- A brief explanation of what the PR is about -->
This adds a "last modified" date to the front matter. I don't know if this is the best way to do it, and it might not be up to the aesthetic standards, but it's what I got working and per this conversation (https://github.com/sylhare/Type-on-Strap/issues/501) I thought I would add a PR. Feel free to modify or reject.

### Screenshot
<!-- Don't forget to provide screenshot if you change the layout of the theme -->
<img width="390" alt="image" src="https://github.com/user-attachments/assets/37912bdd-261b-440f-bedf-64a8169c5147" />
