### PR TITLE
fix [ gulp thumbnails ] error

### DIFF
--- a/assets/gulpfile.js
+++ b/assets/gulpfile.js
@@ -40,7 +40,7 @@ gulp.task('js', function minijs() {
 });
 
 gulp.task("img", async function imging() {
-  const imagemin = await import('gulp-imagemin');
+  const { default: imagemin } = await import('gulp-imagemin');
 
   return gulp.src('img/**/*.{png,svg,jpg,webp,jpeg,gif}')
     .pipe(imagemin.default())
@@ -52,7 +52,7 @@ gulp.task("img", async function imging() {
 
 // Alternative using "sharp" in case "imagemin" does not work, supported formats: heic, heif, jpeg, jpg, png, raw, tiff, webp
 gulp.task('sharp_img', async function () {
-  const responsive = await import('gulp-responsive');
+  const { default: responsive } = await import('gulp-responsive');
   let settings = {
     quality: 85,
     progressive: true,
@@ -68,7 +68,7 @@ gulp.task('sharp_img', async function () {
 });
 
 gulp.task('thumbnails', async function () {
-  const responsive = await import('gulp-responsive');
+  const { default: responsive } = await import('gulp-responsive');
   let settings = {
     width: '50%',
     //format: 'jpeg', // convert to jpeg format
@@ -84,7 +84,7 @@ gulp.task('thumbnails', async function () {
 
 
 gulp.task('thumbnails-all', async function () {
-  const responsive = await import('gulp-responsive');
+  const { default: responsive } = await import('gulp-responsive');
   let settings = {
     width: '50%',
     //format: 'jpeg', // convert to jpeg format


### PR DESCRIPTION
const responsive  add { default: ~ }  syntax

<!-- Thanks for your PR! -->
<!-- If the change is not compatible with GitHub page (https://github.com/github/pages-gem) it won't be merged 😢 -->

### Description
<!-- A brief explanation of what the PR is about -->
<img width="1690" height="418" alt="image" src="https://github.com/user-attachments/assets/9bdcb703-ce4a-41b7-9c29-c89531cb61a8" />


### Screenshot
<!-- Don't forget to provide screenshot if you change the layout of the theme -->
<img width="1676" height="792" alt="image" src="https://github.com/user-attachments/assets/1685800a-60ce-41ec-87f9-552f5666d62f" />
